### PR TITLE
add aqua trivy scanner to github workflow

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -47,7 +47,7 @@ jobs:
           format: 'template'
           template: '@/contrib/html.tpl'
           output: 'public/index.html'
-          exit-code: '1'
+          #exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH,MEDIUM'
@@ -59,3 +59,7 @@ jobs:
       #  with:
       #    github_token: ${{ secrets.GITHUB_TOKEN }}
       #    publish_dir: ./public
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'public/trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 13 * * *"
 
+env:
+  # github.repository as <account>/<repo>
+  IMAGE_BASE: ${{ github.repository }}
+ 
 jobs:
   scan:
     permissions:
@@ -23,7 +27,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'ghcr.io/nichtraunzer/terrarium:latest'
+          image-ref: ${{ env.REGISTRY }}/terrarium:latest
           format: 'sarif'
           output: 'public/trivy-results.sarif'
           exit-code: '1'
@@ -47,7 +51,7 @@ jobs:
           format: 'template'
           template: '@/contrib/html.tpl'
           output: 'public/index.html'
-          #exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH,MEDIUM'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       security-events: write # allow github/codeql-action/upload-sarif
     name: Scan for Security Vulnerabilities
+    if: ${{ github.repository == 'nichtraunzer/terrarium' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,61 @@
+name: Scan terrarium image using trivy
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 13 * * *"
+
+jobs:
+  scan:
+    permissions:
+      contents: write
+      security-events: write # allow github/codeql-action/upload-sarif
+    name: Scan for Security Vulnerabilities
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        
+      - name: Create public folder
+        run: |
+          mkdir -p public/
+      
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'ghcr.io/nichtraunzer/terrarium:latest'
+          format: 'sarif'
+          output: 'public/trivy-results.sarif'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always() 
+        with:
+          sarif_file: 'public/trivy-results.sarif'
+        
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        if: always()
+        continue-on-error: true
+        with:
+          image-ref: 'ghcr.io/nichtraunzer/terrarium:latest'
+          format: 'template'
+          template: '@/contrib/html.tpl'
+          output: 'public/index.html'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+
+      #- name: Save scan results to github pages
+      #  uses: peaceiris/actions-gh-pages@v3
+      #  #if: ${{ github.ref == 'refs/heads/main' }}
+      #  if: always()
+      #  with:
+      #    github_token: ${{ secrets.GITHUB_TOKEN }}
+      #    publish_dir: ./public

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/terrarium:latest
+          image-ref: ${{ env.IMAGE_BASE }}/terrarium:latest
           format: 'sarif'
           output: 'public/trivy-results.sarif'
           exit-code: '1'


### PR DESCRIPTION
Leverage Aqua trivy scanner for scanning of :latest image.
Upload report to github security page.