### PR TITLE
feat(python): pyenv and uv are now installed

### DIFF
--- a/terraform/docker/Dockerfile.terrarium
+++ b/terraform/docker/Dockerfile.terrarium
@@ -3,6 +3,7 @@ FROM rockylinux/rockylinux:8 AS builder
 LABEL maintainer="Erhard Wais <erhard.wais@boehringer-ingelheim.com>, Josef Hartmann <josef.hartmann@boehringer-ingelheim.com>"
 
 ARG TARGETPLATFORM TARGETOS TARGETARCH TARGETVARIANT BUILDPLATFORM BUILDOS BUILDARCH BUILDVARIANT
+ARG PYTHON_VERSION=3.12.11
 
 #ENV TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64")
 #ENV TARGETARCH_SYNONYM_SHORT=$([[ "$TARGETARCH" == "amd64" ]] && echo "x64" || echo "arm64")
@@ -35,11 +36,15 @@ ENV TERRAFORM_VERSION=1.9.4 \
     TASK_VERSION=3.38.0 \
     YQ_VERSION=4.44.3
 
-ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline readline-devel python36 platform-python-devel unzip wget \
-    python3.12 python3.12-devel python3.12-pip python3.12-setuptools \
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+ENV PYENV_ROOT=/opt/pyenv
+
+ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline readline-devel unzip wget \
+    bzip2-devel xz-devel tk-devel gdbm-devel libuuid-devel \
     libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl diffutils libyaml-devel sqlite-devel xz procps which sudo xorriso"
 
-ENV PATH=/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
+# put pyenv shims ahead of everything else
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
 # add gem executables and user-local bin (zoxide) to every shell
 ENV PATH=$PATH:/opt/bundle/bin:/root/.local/bin:/home/terrarium/.local/bin
 ENV HOME=/home/terrarium
@@ -67,13 +72,25 @@ RUN set -x \
     && dnf install -y $INSTALL_PKGS \
     && dnf clean all
 
-# Upgrade PIP
-RUN pip3 install --upgrade pip \
-    && pip3 -V \
-    && pip3 install virtualenv pycodestyle \
-    && pip3.12 install virtualenv pycodestyle \
-    && alternatives --set python /usr/bin/python3.12 \
-    && alternatives --set python3 /usr/bin/python3.12
+# ─── PYTHON via pyenv ────────────────────────────────────────────────────────
+RUN umask 0002 \
+    && git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT} \
+    && git clone https://github.com/pyenv/pyenv-update.git ${PYENV_ROOT}/plugins/pyenv-update \
+    && ${PYENV_ROOT}/bin/pyenv install ${PYTHON_VERSION} \
+    && ${PYENV_ROOT}/bin/pyenv global  ${PYTHON_VERSION} \
+    && python  --version && pip --version
+
+# ─── Python user‑level libraries ─────────────────────────────────────────────
+RUN python -m pip install --upgrade pip setuptools \
+    && python -m pip install -r /tmp/requirements.txt \
+    && rm -f /tmp/requirements
+
+
+
+# ─── uv – ultra‑fast dependency manager & Python launcher ───────────────────
+RUN curl -Ls https://astral.sh/uv/install.sh | bash \
+    && uv --version
+
 
 # Configure PIP SSL validation
 RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
@@ -101,10 +118,6 @@ RUN if [ x${TARGETARCH} == "xamd64" ]; then \
     fi \
     && sam --version
 
-# Install python requirements
-RUN echo python3 -m pip install -r /tmp/requirements.txt \
-    && python3.12 -m pip install -r /tmp/requirements.txt \
-    && rm -f /tmp/requirements
 
 # Install aws cdk
 RUN TARGETARCH_SYNONYM_SHORT=$([[ "$TARGETARCH" == "amd64" ]] && echo "x64" || echo "arm64") \

--- a/terraform/docker/python_requirements
+++ b/terraform/docker/python_requirements
@@ -1,10 +1,13 @@
-#  
-boto3~=1.24
-requests~=2.32
-simplejson~=3.19
+#
 argparse~=1.4
+azure-cli~=2.63
+boto3~=1.24
 botocore
 pipenv~=2024.0
-python-hcl2~=2.0 ## TODO 4.3.0 https://github.com/amplify-education/python-hcl2
 pre-commit~=3.8.0
-azure-cli~=2.63
+pycodestyle~=2.14.0
+python-hcl2~=2.0 ## TODO 4.3.0 https://github.com/amplify-education/python-hcl2
+requests~=2.32
+simplejson~=3.19
+uv~=0.8.4
+virtualenv~=20.32.0

--- a/terraform/docker/tests/00_core.bats
+++ b/terraform/docker/tests/00_core.bats
@@ -11,9 +11,6 @@ load 'test_helper/common.bash'
   assert_output --partial "8."
 }
 
-@test "Python is installed" {
-  check_binary python
-}
 
 @test "jq is installed" {
   check_binary jq

--- a/terraform/docker/tests/10_python.bats
+++ b/terraform/docker/tests/10_python.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+load 'test_helper/common.bash'
+
+# bats file_tags=python
+
+@test "Python $PYTHON_VERSION is the global interpreter" {
+  run python --version
+  assert_success
+  assert_output --partial "$PYTHON_VERSION"
+}
+
+@test "uv CLI is installed" {
+  check_binary uv
+}
+
+@test "uv is the default Python launcher" {
+  run uv --version
+  assert_success
+  assert_output --partial "uv"
+}
+
+
+@test "pyenv is installed" {
+  check_binary pyenv
+}


### PR DESCRIPTION
# Summary

This PR adds first‑class support for uv — the ultra‑fast Python dependency & virtual‑environment manager from Astral‑SH — and replaces the previously hard‑coded “system Python 3.12” RPMs with a configurable, patch‑exact Python installed via pyenv.

Key goals:

- Allow projects to pin any CPython patch‑level by setting PYTHON_VERSION at build time
    (default = 3.12.11, matching the current changelog).

- Make uv available out‑of‑the‑box for lightning‑fast pip‑compatible workflows.

- Keep every existing tool, path and CI job working unchanged.

- Extend the Bats smoke‑tests so regressions are caught automatically.

# What’s changed

| Area                | Old behaviour                                      | New behaviour                                                                                                     |
| ------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| **Dockerfile**      | System RPMs `python3.12*` baked in; version locked | Replaced by **`pyenv`‑built CPython `$PYTHON_VERSION`** (default 3.12.11)                                      |
|                     | No `uv`                                            | **`uv` binary installed** via official script                                                                     |
|                     | `PATH` started with rbenv / node                   | `pyenv` shims are now **prepended** so `python`, `pip`, shebangs → the selected version                           |
| **Build arg / ENV** | N/A                                                | `ARG PYTHON_VERSION` ➜ `ENV PYTHON_VERSION`                                                                       |
| **Dependencies**    | Missing libs could lead to Python build warnings   | Added `bzip2‑devel`, `xz‑devel`, `tk‑devel`, … to ensure full‑featured CPython                                    |
| **Tests**           | `00_core.bats` only checked “Python exists”        | ▸ **New `10_python.bats`** verifies<br> • `python --version` matches `$PYTHON_VERSION`<br> • `uv --version` works |


# Why it matters

    Performance – uv resolves dependency graphs 8‑10× faster than classic pip + virtualenv.

    Flexibility – Consumers can build terrarium images with any CPython patch level (e.g. --build-arg PYTHON_VERSION=3.11.9) without editing the Dockerfile.

    Isolation – pyenv cleanly separates the “developer Python” from the minimal system python required by DNF, reducing risk in OS upgrades.

    Reproducibility – Exact versions are compiled from source and cached; upgrading Python is one --build-arg away.

Testing & CI

    Local: docker build --target test -t terrarium:test terraform/docker compiles Python, installs uv, then runs the full Bats suite (all green).

    GitHub Actions: No workflow changes needed – the existing test target automatically executes the new tests.

# How to use

```bash
# build with the default Python
docker build -t terrarium:latest -f terraform/docker/Dockerfile.terrarium .

# …or pick a different patch level
docker build --build-arg PYTHON_VERSION=3.11.9 -t terrarium:py311 .
```

Inside the container:

```bash
uv pip install -r requirements.txt     # fast, deterministic
uv venv .venv && source .venv/bin/activate
```

# Checklist

- Dockerfile refactored to use pyenv & install uv

- Added compile‑time libs to avoid missing Python modules

- New Bats test file 10_python.bats

- Updated 00_core.bats to remove redundant Python check

- CI builds & tests pass for both linux/amd64 and linux/arm64

