### PR TITLE
Fixed Path for Python Installed Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2025-08-18 PR #44 feat(tools): added kubectl and helm with validation tests
+
+https://github.com/nichtraunzer/terrarium/pull/44
+
+### Added
+
+- `kubectl` and `helm` installed with install validation tests.
+
+### Changed
+
+- Updated `Dockerfile.terrarium` and `kubectl` to version `1.33.3` and actually install.
+- Updated `Dockerfile.terrarium` and `helm` to version `3.18.4` and actually install.
+- `k8s` validation tests for `kubectl` and `helm`.
+
 ## 2025-08-08 PR #41 — feat(python): pyenv and uv are now installed (merged 2025‑08‑08)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2025-08-22 PR #46 Make Terrarium image UID‑agnostic via stable devtools group; fix Ruby toolchain permissions & PATH for Dev Containers
+
+https://github.com/nichtraunzer/terrarium/pull/46
+
+### Changed
+- Image is now **UID‑agnostic** by introducing a stable `devtools` group (`DEVTOOLS_GID`, default `2001`) and applying setgid + group‑writable perms to `/opt/bundle` and `/opt/rbenv` (optional: `/opt/pyenv`, `/opt/tenv`).
+- Toolchain PATH and `rbenv` init are loaded for **login and non‑login shells** via `/etc/profile.d/10-terrarium-path.sh` and `/etc/bashrc.d/10-terrarium-path.sh`.
+
+### Added
+- Cooperative `umask 0002` for dev shells to keep group‑writable files.
+
+### Fixed
+- `kitchen` / `cinc-auditor` reliably resolve on PATH; **no more Dev Container `postCreateCommand` chowns** required. Downstream users just add their user to `devtools` (`usermod -aG devtools <user>`).
+
+
 ## 2025-08-18 PR #44 feat(tools): added kubectl and helm with validation tests
 
 https://github.com/nichtraunzer/terrarium/pull/44

--- a/terraform/docker/Dockerfile.terrarium
+++ b/terraform/docker/Dockerfile.terrarium
@@ -5,8 +5,8 @@ LABEL maintainer="Erhard Wais <erhard.wais@boehringer-ingelheim.com>, Josef Hart
 ARG TARGETPLATFORM TARGETOS TARGETARCH TARGETVARIANT BUILDPLATFORM BUILDOS BUILDARCH BUILDVARIANT
 ARG PYTHON_VERSION=3.12.11
 
-#ENV TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64")
-#ENV TARGETARCH_SYNONYM_SHORT=$([[ "$TARGETARCH" == "amd64" ]] && echo "x64" || echo "arm64")
+# Stable supplementary group for toolchains (configurable)
+ARG DEVTOOLS_GID=2001
 
 ENV TERRAFORM_VERSION=1.9.4 \
     TERRAFORM_VERSION_DEPRECATED=1.4.6 \
@@ -43,9 +43,9 @@ ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch read
     bzip2-devel xz-devel tk-devel gdbm-devel libuuid-devel \
     libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl diffutils libyaml-devel sqlite-devel xz procps which sudo xorriso"
 
-# put pyenv shims ahead of everything else
+# Put pyenv & rbenv shims ahead of everything else
 ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
-# add gem executables and user-local bin (zoxide) to every shell
+# Add gem executables and user-local bin (zoxide) to every shell
 ENV PATH=$PATH:/opt/bundle/bin:/root/.local/bin:/home/terrarium/.local/bin
 ENV HOME=/home/terrarium
 
@@ -54,14 +54,13 @@ COPY python_requirements /tmp/requirements.txt
 RUN echo "I am running on ${BUILDPLATFORM}, ${BUILDOS}, ${BUILDARCH}, ${BUILDVARIANT}, \
     building for ${TARGETPLATFORM}, ${TARGETOS}, ${TARGETARCH}, ${TARGETVARIANT}."
 
-# Updates OS packages
+# OS & tools
 RUN dnf install -y redhat-lsb-core \
     && lsb_release -d \
     && dnf update -y \
     && lsb_release -d \
     && dnf clean all
 
-# Install jq
 RUN dnf install -y epel-release \
     && crb enable \
     && dnf install -y jq parallel \
@@ -72,7 +71,12 @@ RUN set -x \
     && dnf install -y $INSTALL_PKGS \
     && dnf clean all
 
-# ─── PYTHON via pyenv ────────────────────────────────────────────────────────
+# ─── UID‑agnostic toolchains: create stable group and set perms ──────────────
+RUN groupadd -g ${DEVTOOLS_GID} devtools || true \
+    && install -d -m 0775 -o 1001 -g devtools "${HOME}" \
+    && install -d -m 2775 -o 0    -g devtools "${GEM_HOME}"
+
+# ─── Python via pyenv ────────────────────────────────────────────────────────
 RUN umask 0002 \
     && git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT} \
     && git clone https://github.com/pyenv/pyenv-update.git ${PYENV_ROOT}/plugins/pyenv-update \
@@ -80,23 +84,24 @@ RUN umask 0002 \
     && ${PYENV_ROOT}/bin/pyenv global  ${PYTHON_VERSION} \
     && python  --version && pip --version
 
-# ─── Python user‑level libraries ─────────────────────────────────────────────
+# allow pyenv installs at runtime
+RUN chgrp -R devtools /opt/pyenv \
+    && find /opt/pyenv -type d -exec chmod 2775 {} + \
+    && find /opt/pyenv -type f -exec chmod g+rw {} + \
+    && find /opt/pyenv -type f -perm -u=x -exec chmod g+x {} +
+
+# Python libs
 RUN python -m pip install --upgrade pip setuptools \
     && python -m pip install -r /tmp/requirements.txt \
     && rm -f /tmp/requirements
 
+# uv
+RUN curl -Ls https://astral.sh/uv/install.sh | bash && uv --version
 
+# pip SSL
+RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt && pip config list
 
-# ─── uv – ultra‑fast dependency manager & Python launcher ───────────────────
-RUN curl -Ls https://astral.sh/uv/install.sh | bash \
-    && uv --version
-
-
-# Configure PIP SSL validation
-RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
-    && pip config list
-
-# Install awscli2
+# awscli2
 RUN TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64") \
     && curl "https://awscli.amazonaws.com/awscli-exe-${TARGETOS}-${TARGETARCH_SYNONYM}.zip" -o "awscliv2.zip" \
     && unzip -qq awscliv2.zip \
@@ -105,66 +110,67 @@ RUN TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo
     && rm -Rf ./aws \
     && /usr/local/bin/aws --version
 
-# Install awssamcli
-RUN if [ x${TARGETARCH} == "xamd64" ]; then \
-    TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "use_pip") \
-    && curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-${TARGETOS}-${TARGETARCH_SYNONYM}.zip" -o "awssam.zip" \
-    && unzip -qq -d awssam awssam.zip \
-    && ./awssam/install \
-    && rm -f awssam.zip \
-    && rm -Rf ./awssam; \
+# SAM
+RUN if [ "x${TARGETARCH}" = "xamd64" ]; then \
+    TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "use_pip"); \
+    curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-${TARGETOS}-${TARGETARCH_SYNONYM}.zip" -o "awssam.zip"; \
+    unzip -qq -d awssam awssam.zip; \
+    ./awssam/install; \
+    rm -f awssam.zip; rm -Rf ./awssam; \
     else \
     pip3 install aws-sam-cli; \
-    fi \
-    && sam --version
+    fi && sam --version
 
-
-# Install aws cdk
+# Node + CDK
 RUN TARGETARCH_SYNONYM_SHORT=$([[ "$TARGETARCH" == "amd64" ]] && echo "x64" || echo "arm64") \
     && wget -q "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz" \
     && xzcat node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz | tar xpf - -C /opt/ \
     && rm -f node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz \
     && mv /opt/node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT} /opt/node \
     && /opt/node/bin/npm install -g aws-cdk \
-    && chown -R 1001:0 /opt/node && chmod +x /opt/node/bin/* \
-    && node --version \
-    && cdk --version
+    && chown -R 0:0 /opt/node && chmod -R a+rX /opt/node \
+    && node --version && cdk --version
 
-# Install tenv
+# tenv
 RUN TENV_ARCH=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && yum install -y https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/tenv_v${TENV_VERSION}_${TENV_ARCH}.rpm \
     && tenv tf install ${TERRAFORM_VERSION} \
     && tenv tf install ${TERRAFORM_VERSION_DEPRECATED} \
     && tenv tf use ${TERRAFORM_VERSION} \
-    && terraform -version \
-    && tenv tf list \
+    && terraform -version && tenv tf list \
     && echo 'export PATH=$(/usr/bin/tenv update-path)' > /etc/profile.d/tenv.sh \
     && chown -R 1001:0 "${TENV_ROOT}" \
     && chmod -R 2775 "${TENV_ROOT}"
 
-# Install tflint
+# Allow devs to manage Terraform versions at runtime
+RUN chgrp -R devtools /opt/tenv \
+    && find /opt/tenv -type d -exec chmod 2775 {} + \
+    && find /opt/tenv -type f -exec chmod g+rw {} + \
+    && find /opt/tenv -type f -perm -u=x -exec chmod g+x {} +
+
+
+
+# tflint
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && wget -q -O /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TARGETARCH_SYNONYM_SHORT2}.zip" \
     && unzip /tmp/tflint.zip -d /usr/local/bin \
-    && rm -rf /tmp/tflint.zip \
-    && tflint --version
+    && rm -rf /tmp/tflint.zip && tflint --version
 
-# Install Packer
+# packer
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && wget -q -O /tmp/packer.zip "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
     && unzip /tmp/packer.zip -d /usr/local/bin packer \
-    && rm -rf /tmp/packer.zip \
-    && packer --version
+    && rm -rf /tmp/packer.zip && packer --version
 
-## Install consul-cli
+# consul
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && wget -q -O /tmp/consul.zip -q "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
+    && wget -q -O /tmp/consul.zip "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
     && unzip /tmp/consul.zip -d /usr/local/bin consul \
     && rm -f /tmp/consul.zip \
     && chmod +x /usr/local/bin/consul \
     && /usr/local/bin/consul -version
 
-# Install terraform-config-inspect
+# terraform-config-inspect
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && wget -q -O /tmp/terraform-config-inspect.tar.gz https://github.com/nichtraunzer/terraform-config-inspect/releases/download/v${TERRAFORM_CONFIG_INSPECT_VERSION}/terraform-config-inspect_${TERRAFORM_CONFIG_INSPECT_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
     && tar zxpf /tmp/terraform-config-inspect.tar.gz -C /usr/local/bin/ terraform-config-inspect \
@@ -172,7 +178,7 @@ RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" |
     && chmod 755 /usr/local/bin/terraform-config-inspect \
     && /usr/local/bin/terraform-config-inspect
 
-# Install Terraform Docs
+# terraform-docs
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && wget -q -O /tmp/terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
     && tar zxpf /tmp/terraform-docs.tar.gz -C /usr/local/bin/ terraform-docs \
@@ -180,7 +186,7 @@ RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" |
     && chmod +x /usr/local/bin/terraform-docs \
     && /usr/local/bin/terraform-docs --help
 
-# Install mozilla/sops and AGE
+# sops & age
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && TARGETARCH_SYNONYM_SHORT3=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64") \
     && dnf install -y https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.${TARGETARCH_SYNONYM_SHORT3}.rpm \
@@ -191,73 +197,50 @@ RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" |
     && /usr/local/bin/age --version \
     && dnf clean all
 
-# Install starship and zoxide
+# starship & zoxide
 RUN TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64") \
     && wget -q -O /tmp/starship.sh https://starship.rs/install.sh \
-    && chmod +x /tmp/starship.sh \
-    && /tmp/starship.sh --yes \
-    && rm -f /tmp/starship.sh \
+    && chmod +x /tmp/starship.sh && /tmp/starship.sh --yes && rm -f /tmp/starship.sh \
     && wget -q -O /tmp/zoxide.sh https://webinstall.dev/zoxide \
-    && chmod +x /tmp/zoxide.sh \
-    && /tmp/zoxide.sh \
-    && rm -f /tmp/zoxide.sh
+    && chmod +x /tmp/zoxide.sh && /tmp/zoxide.sh && rm -f /tmp/zoxide.sh
 
-# Install GO
+# Go & task
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && wget -q -O /tmp/go.tar.gz https://golang.org/dl/go${GO_VERSION}.${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
-    && tar -C /usr/local -xzf /tmp/go.tar.gz \
-    && rm -f /tmp/go.tar.gz
+    && tar -C /usr/local -xzf /tmp/go.tar.gz && rm -f /tmp/go.tar.gz
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d v${TASK_VERSION} && task --version
 
-# Install go-task
-RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d v${TASK_VERSION} \
-    && task --version
-
-# Install yq
+# yq
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && wget -q -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH_SYNONYM_SHORT2} \
-    && chmod +x /usr/local/bin/yq \
-    && /usr/local/bin/yq --version
+    && chmod +x /usr/local/bin/yq && /usr/local/bin/yq --version
 
-# kubectl
-RUN curl -fsSLo /usr/local/bin/kubectl \
-    https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl \
-    && chmod +x /usr/local/bin/kubectl \
-    && kubectl version --client=true
-
-# helm
+# kubectl / helm
+RUN curl -fsSLo /usr/local/bin/kubectl https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl \
+    && chmod +x /usr/local/bin/kubectl && kubectl version --client=true
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && curl -fsSLo /tmp/helm.tar.gz "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
     && tar -zxvf /tmp/helm.tar.gz --strip-components=1 -C /usr/local/bin linux-${TARGETARCH_SYNONYM_SHORT2}/helm \
-    && rm -f /tmp/helm.tar.gz \
-    && helm version
+    && rm -f /tmp/helm.tar.gz && helm version
 
 ENV PATH=$PATH:/usr/local/go/bin
 
-RUN chown -R 1001:0 ${HOME} \
-    && chmod -R g+rw ${HOME} \
-    && mkdir -p ${GEM_HOME} \
-    && chmod 2770 ${GEM_HOME}
 
-RUN chown -R 1001:0 ${GEM_HOME} \
-    && chmod -R g+rw ${GEM_HOME} \
-    && ls -lisa ${HOME} ${GEM_HOME}
-
-# ─── OpenSSL build prereqs for ruby-build on RHEL/Rocky ───────────────
+# OpenSSL prereq
 RUN dnf -y install perl-IPC-Cmd && dnf clean all
 
-# setup ruby env and bundler gems
-# RUBY https://syslint.com/blog/tutorial/how-to-install-ruby-on-rails-with-rbenv-on-centos-7-or-rhel-7/
+# Ruby / rbenv / bundler / gems
 RUN cd /opt \
     && umask 0002 \
     && git clone https://github.com/rbenv/rbenv.git /opt/rbenv \
-    && echo 'export PATH="/opt/rbenv/shims:/opt/rbenv/bin:$PATH"' >> ~/.bash_profile \
-    && echo 'eval "$(rbenv init -)"' >> ~/.bash_profile \
-    && source ~/.bash_profile \
+    && echo 'export PATH="/opt/rbenv/shims:/opt/rbenv/bin:$PATH"' >> ${HOME}/.bash_profile \
+    && echo 'eval "$(rbenv init -)"' >> ${HOME}/.bash_profile \
+    && source ${HOME}/.bash_profile \
     && git clone https://github.com/rbenv/ruby-build.git /opt/rbenv/plugins/ruby-build \
-    && echo 'export PATH="/opt/rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bash_profile \
-    && source ~/.bash_profile \
+    && echo 'export PATH="/opt/rbenv/plugins/ruby-build/bin:$PATH"' >> ${HOME}/.bash_profile \
+    && source ${HOME}/.bash_profile \
     && rbenv install ${RUBY_VERSION} \
-    && rbenv global ${RUBY_VERSION} \
+    && rbenv global  ${RUBY_VERSION} \
     && gem install bundler -v ${BUNDLER_VERSION} \
     && RBENV_VERSION=${RUBY_VERSION} gem install bundler -v ${BUNDLER_VERSION} \
     && bundle config default ${BUNDLER_VERSION} \
@@ -265,14 +248,14 @@ RUN cd /opt \
     && bundle config set --global path ${GEM_HOME} \
     && RBENV_VERSION=${RUBY_VERSION} bundle config set --global path ${GEM_HOME}
 
-RUN source ~/.bash_profile \
+RUN source ${HOME}/.bash_profile \
     && rbenv install ${RUBY_VERSION_DEPRECATED} \
     && RBENV_VERSION=${RUBY_VERSION_DEPRECATED} gem install bundler -v ${BUNDLER_VERSION_DEPRECATED} \
     && rbenv install -L
 
 COPY Gemfile Gemfile.lock ${GEM_HOME}/
 
-RUN source ~/.bash_profile \
+RUN source ${HOME}/.bash_profile \
     && RBENV_VERSION=${RUBY_VERSION} ruby --version \
     && RBENV_VERSION=${RUBY_VERSION_DEPRECATED} ruby --version \
     && cd ${GEM_HOME} \
@@ -281,15 +264,37 @@ RUN source ~/.bash_profile \
     && bundle binstubs bundler --force \
     && rm -Rf ${HOME}/.bundle/cache
 
-# Install test dependencies to allow for testing of output image
-# --- add latest bats-core (one small layer, ~1 MiB) ---
-RUN git clone --depth 1 --branch v1.11.0 \
-    https://github.com/bats-core/bats-core.git /opt/bats-core \
+# ─── Make /opt/bundle and /opt/rbenv group‑writable, setgid, and executable ─
+RUN chgrp -R devtools ${GEM_HOME} /opt/rbenv \
+    && find ${GEM_HOME} /opt/rbenv -type d -exec chmod 2775 {} + \
+    && find ${GEM_HOME} /opt/rbenv -type f -exec chmod g+rw {} + \
+    && find ${GEM_HOME} /opt/rbenv -type f -perm -u=x -exec chmod g+x {} + \
+    && rbenv rehash || true
+
+# PATH and rbenv init for non‑login shells (devcontainers, VS Code tasks, etc.)
+RUN mkdir -p /etc/profile.d \
+    && printf '%s\n' \
+    'export RBENV_ROOT=/opt/rbenv' \
+    'export PATH=/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:/opt/bundle/bin:$PATH' \
+    'if command -v rbenv >/dev/null 2>&1; then eval "$(rbenv init -)"; fi' \
+    > /etc/profile.d/10-terrarium-path.sh \
+    && chmod 0644 /etc/profile.d/10-terrarium-path.sh
+
+# On RHEL/Rocky, login shells source /etc/profile.d, non‑login ones don’t. Dev Containers usually probe with a login shell, but terminals/tasks might be non‑login.
+RUN mkdir -p /etc/bashrc.d \
+    && printf '%s\n' \
+    'export RBENV_ROOT=/opt/rbenv' \
+    'export PATH=/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:/opt/bundle/bin:$PATH' \
+    'if command -v rbenv >/dev/null 2>&1; then eval "$(rbenv init -)"; fi' \
+    > /etc/bashrc.d/10-terrarium-path.sh \
+    && chmod 0644 /etc/bashrc.d/10-terrarium-path.sh
+
+
+# Bats & tests
+RUN git clone --depth 1 --branch v1.11.0 https://github.com/bats-core/bats-core.git /opt/bats-core \
     && /opt/bats-core/install.sh /usr/local \
     && bats --version
 COPY tests /home/terrarium/tests
-
-
 
 WORKDIR $HOME
 CMD ["/bin/bash", "-i", "-l"]
@@ -297,23 +302,22 @@ CMD ["/bin/bash", "-i", "-l"]
 ################  Stage 2 — test  ###################
 FROM builder AS test
 
-# bring in the official bats-support & bats-assert helpers
+# Bats helpers
 RUN git clone https://github.com/bats-core/bats-support.git /home/terrarium/tests/test_helper/bats-support \
-    && git clone https://github.com/bats-core/bats-assert.git   /home/terrarium/tests/test_helper/bats-assert
+    && git clone https://github.com/bats-core/bats-assert.git   /home/terrarium/tests/test_helper/bats-assert \
+    && find /home/terrarium/tests -type f -name "*.bats" -exec chmod +x {} \;
 
-# make all tests (and helpers) executable
-RUN find /home/terrarium/tests -type f -name "*.bats" -exec chmod +x {} \;
-
-# ---- give UID 1001 a real name (optional hardening) ----
-RUN useradd -u 1001 terrarium
+# Give UID 1001 a name and add to devtools (so group access works)
+ARG DEVTOOLS_GID=2001
+RUN groupadd -g ${DEVTOOLS_GID} devtools || true \
+    && useradd -u 1001 terrarium || true \
+    && usermod -aG devtools terrarium
 USER 1001:0
 
-# now run them, emitting a proper JUnit XML report
+RUN chown -R terrarium:devtools /home/terrarium/tests
+
 RUN bats --report-formatter junit /home/terrarium/tests --output /home/terrarium --jobs $(nproc)
 
-# Make sure test files under /home/terrarium/tests are owned by the user and are executable
 ################  Stage 3 — final runtime image  ####
-# IMPORTANT: Do not copy bats or tests.
 FROM builder AS final
-# (Optional) clean caches, strip docs
 CMD ["/bin/bash"]

--- a/terraform/docker/Dockerfile.terrarium
+++ b/terraform/docker/Dockerfile.terrarium
@@ -45,7 +45,8 @@ ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch read
     libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl diffutils libyaml-devel sqlite-devel xz procps which sudo xorriso"
 
 # Put pyenv & rbenv shims ahead of everything else
-ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
+# ${PYENV_ROOT}/versions/${PYTHON_VERSION}/bin should have AzureCLI, commitlint etc form python_requirements hence included in path to make these tools available
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PYENV_ROOT}/versions/${PYTHON_VERSION}/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
 # Add gem executables and user-local bin (zoxide) to every shell
 ENV PATH=$PATH:/opt/bundle/bin:/root/.local/bin:/home/terrarium/.local/bin
 ENV HOME=/home/terrarium
@@ -91,7 +92,7 @@ RUN chgrp -R devtools /opt/pyenv \
     && find /opt/pyenv -type f -exec chmod g+rw {} + \
     && find /opt/pyenv -type f -perm -u=x -exec chmod g+x {} +
 
-# Python libs
+# Python libs (these will be installed to ${PYENV_ROOT}/versions/${PYTHON_VERSION}/bin so should be on the path as s et above)
 RUN python -m pip install --upgrade pip setuptools \
     && python -m pip install -r /tmp/requirements.txt \
     && rm -f /tmp/requirements

--- a/terraform/docker/Dockerfile.terrarium
+++ b/terraform/docker/Dockerfile.terrarium
@@ -20,6 +20,7 @@ ENV TERRAFORM_VERSION=1.9.4 \
     TENV_AUTO_INSTALL=true \
     TENV_ROOT=/opt/tenv \
     TFLINT_VERSION=0.52.0 \
+    TFSEC_VERSION=1.28.14 \
     NODEJS_VERSION=20.16.0 \
     BUNDLER_VERSION=2.5.17 \
     BUNDLER_VERSION_DEPRECATED=2.4.13 \
@@ -186,6 +187,13 @@ RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" |
     && chmod +x /usr/local/bin/terraform-docs \
     && /usr/local/bin/terraform-docs --help
 
+# tfsec
+RUN TFSEC_ARCH=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
+    && wget -O /usr/local/bin/tfsec \
+    "https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-${TFSEC_ARCH}" \
+    && chmod +x /usr/local/bin/tfsec \
+    && tfsec --version
+
 # sops & age
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && TARGETARCH_SYNONYM_SHORT3=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64") \
@@ -289,6 +297,9 @@ RUN mkdir -p /etc/bashrc.d \
     > /etc/bashrc.d/10-terrarium-path.sh \
     && chmod 0644 /etc/bashrc.d/10-terrarium-path.sh
 
+RUN printf '%s\n' 'umask 0002' >> /etc/profile.d/10-terrarium-path.sh \
+    && printf '%s\n' 'umask 0002' >> /etc/bashrc.d/10-terrarium-path.sh
+
 
 # Bats & tests
 RUN git clone --depth 1 --branch v1.11.0 https://github.com/bats-core/bats-core.git /opt/bats-core \
@@ -312,9 +323,11 @@ ARG DEVTOOLS_GID=2001
 RUN groupadd -g ${DEVTOOLS_GID} devtools || true \
     && useradd -u 1001 terrarium || true \
     && usermod -aG devtools terrarium
-USER 1001:0
+USER root
 
 RUN chown -R terrarium:devtools /home/terrarium/tests
+
+USER terrarium
 
 RUN bats --report-formatter junit /home/terrarium/tests --output /home/terrarium --jobs $(nproc)
 

--- a/terraform/docker/Dockerfile.terrarium
+++ b/terraform/docker/Dockerfile.terrarium
@@ -252,7 +252,6 @@ RUN dnf -y install perl-IPC-Cmd && dnf clean all
 
 
 # Ruby / rbenv / bundler / gems
-=======
 # ─── OpenSSL build prereqs for ruby-build on RHEL/Rocky ───────────────
 RUN dnf -y install perl-IPC-Cmd && dnf clean all
 

--- a/terraform/docker/Dockerfile.terrarium
+++ b/terraform/docker/Dockerfile.terrarium
@@ -1,321 +1,220 @@
-# --------- Global args used across stages ---------
+FROM rockylinux/rockylinux:8 AS builder
+
+LABEL maintainer="Erhard Wais <erhard.wais@boehringer-ingelheim.com>, Josef Hartmann <josef.hartmann@boehringer-ingelheim.com>"
+
+ARG TARGETPLATFORM TARGETOS TARGETARCH TARGETVARIANT BUILDPLATFORM BUILDOS BUILDARCH BUILDVARIANT
 ARG PYTHON_VERSION=3.12.11
-ARG RUBY_VERSION=3.4.1
-ARG BUNDLER_VERSION=2.7.1
-ARG GEM_HOME=/opt/bundle
-ARG BATS_CORE_VERSION=1.11.0
 
-# ================= Stage 0 — buildlang (compile on Rocky 9) =================
-FROM rockylinux:9 AS buildlang
-ARG PYTHON_VERSION RUBY_VERSION BUNDLER_VERSION GEM_HOME
+#ENV TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64")
+#ENV TARGETARCH_SYNONYM_SHORT=$([[ "$TARGETARCH" == "amd64" ]] && echo "x64" || echo "arm64")
 
-ENV PYENV_ROOT=/opt/pyenv \
+ENV TERRAFORM_VERSION=1.9.4 \
+    TERRAFORM_VERSION_DEPRECATED=1.4.6 \
+    TERRAFORM_CONFIG_INSPECT_VERSION=0.2.0 \
+    TERRAFORM_DOCS_VERSION=v0.19.0 \
+    RUBY_VERSION=3.3.4 \
+    RUBY_VERSION_DEPRECATED=3.2.2 \
+    PACKER_VERSION=1.11.2 \
+    CONSUL_VERSION=1.19.1 \
+    TENV_VERSION=3.0.0 \
+    TENV_AUTO_INSTALL=true \
+    TENV_ROOT=/opt/tenv \
+    TFLINT_VERSION=0.52.0 \
+    NODEJS_VERSION=20.16.0 \
+    BUNDLER_VERSION=2.5.17 \
+    BUNDLER_VERSION_DEPRECATED=2.4.13 \
+    GEM_HOME=/opt/bundle \
     RBENV_ROOT=/opt/rbenv \
-    GEM_HOME=${GEM_HOME}
-# Put shims first so compilers/env see the right python/ruby
-ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${RBENV_ROOT}/shims:${RBENV_ROOT}/bin:$PATH
+    RBENV_SHELL=bash \
+    SOPS_VERSION=3.9.0 \
+    AGE_VERSION=1.2.0 \
+    HELM_VERSION=3.18.4 \
+    KUBECTL_VERSION=1.33.3 \
+    STARSHIP_VERSION=1.20.1 \
+    ZOXIDE_VERSION=0.9.4 \
+    GO_VERSION=1.24.5 \
+    TASK_VERSION=3.38.0 \
+    YQ_VERSION=4.44.3
 
-# Full toolchain + all -devel libs needed by CPython/Ruby & native gems
-# NOTE: don't install 'curl' here to avoid conflict with curl-minimal on EL9.
-RUN dnf -y update \
-    && dnf -y install dnf-plugins-core \
-    && dnf config-manager --set-enabled crb \
-    && dnf -y groupinstall "Development Tools" \
-    && dnf -y install \
-    git wget tar patch which sudo procps diffutils xz unzip \
-    gcc gcc-c++ make autoconf automake libtool bison \
-    zlib zlib-devel bzip2 bzip2-devel xz xz-devel \
-    openssl openssl-devel libffi libffi-devel \
-    sqlite sqlite-devel libyaml libyaml-devel \
-    readline readline-devel gdbm gdbm-devel libuuid libuuid-devel \
-    tk tk-devel \
-    xorriso \
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+ENV PYENV_ROOT=/opt/pyenv
+
+ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline readline-devel unzip wget \
+    bzip2-devel xz-devel tk-devel gdbm-devel libuuid-devel \
+    libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl diffutils libyaml-devel sqlite-devel xz procps which sudo xorriso"
+
+# put pyenv shims ahead of everything else
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
+# add gem executables and user-local bin (zoxide) to every shell
+ENV PATH=$PATH:/opt/bundle/bin:/root/.local/bin:/home/terrarium/.local/bin
+ENV HOME=/home/terrarium
+
+COPY python_requirements /tmp/requirements.txt
+
+RUN echo "I am running on ${BUILDPLATFORM}, ${BUILDOS}, ${BUILDARCH}, ${BUILDVARIANT}, \
+    building for ${TARGETPLATFORM}, ${TARGETOS}, ${TARGETARCH}, ${TARGETVARIANT}."
+
+# Updates OS packages
+RUN dnf install -y redhat-lsb-core \
+    && lsb_release -d \
+    && dnf update -y \
+    && lsb_release -d \
     && dnf clean all
 
-# ---- pyenv & Python ----
+# Install jq
+RUN dnf install -y epel-release \
+    && crb enable \
+    && dnf install -y jq parallel \
+    && jq -Version \
+    && dnf clean all
+
+RUN set -x \
+    && dnf install -y $INSTALL_PKGS \
+    && dnf clean all
+
+# ─── PYTHON via pyenv ────────────────────────────────────────────────────────
 RUN umask 0002 \
     && git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT} \
     && git clone https://github.com/pyenv/pyenv-update.git ${PYENV_ROOT}/plugins/pyenv-update \
     && ${PYENV_ROOT}/bin/pyenv install ${PYTHON_VERSION} \
     && ${PYENV_ROOT}/bin/pyenv global  ${PYTHON_VERSION} \
-    && python --version && pip --version
+    && python  --version && pip --version
 
-# ---- rbenv & Ruby + Bundler (single supported version) ----
-RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_ROOT} \
-    && git clone https://github.com/rbenv/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build \
-    && ${RBENV_ROOT}/bin/rbenv install ${RUBY_VERSION} \
-    && ${RBENV_ROOT}/bin/rbenv global ${RUBY_VERSION} \
-    && RBENV_VERSION=${RUBY_VERSION} gem install bundler -v ${BUNDLER_VERSION}
+# ─── Python user‑level libraries ─────────────────────────────────────────────
+RUN python -m pip install --upgrade pip setuptools \
+    && python -m pip install -r /tmp/requirements.txt \
+    && rm -f /tmp/requirements
 
-# Install the repo Gemfile into /opt/bundle (no direct gem installs of kitchen/cinc!)
-COPY Gemfile Gemfile.lock /tmp/gems/
-RUN RBENV_VERSION=${RUBY_VERSION} bundle config set --global path ${GEM_HOME} \
-    && RBENV_VERSION=${RUBY_VERSION} bash -lc "cd /tmp/gems \
-    && BUNDLE_SILENCE_ROOT_WARNING=true bundle install --full-index --jobs=6 \
-    && bundle binstubs bundler --force" \
-    && rm -rf /root/.bundle/cache
 
-# ================= Stage 1 — builder (UBI 9) =================
-FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-LABEL maintainer="Erhard Wais <erhard.wais@boehringer-ingelheim.com>, Josef Hartmann <josef.hartmann@boehringer-ingelheim.com>"
+# ─── uv – ultra‑fast dependency manager & Python launcher ───────────────────
+RUN curl -Ls https://astral.sh/uv/install.sh | bash \
+    && uv --version
 
-ARG TARGETPLATFORM TARGETOS TARGETARCH TARGETVARIANT BUILDPLATFORM BUILDOS BUILDARCH BUILDVARIANT
-ARG PYTHON_VERSION
-ARG GEM_HOME
-ARG BATS_CORE_VERSION
 
-# Tool versions (deprecated pins removed)
-ENV AGE_VERSION=1.2.1 \
-    AWS_CDK_VERSION=2.1024.0 \
-    BUNDLER_VERSION=2.7.1 \
-    CONSUL_VERSION=1.21.3 \
-    GEM_HOME=/opt/bundle \
-    GO_VERSION=1.24.6 \
-    HELM_VERSION=3.18.4 \
-    KUBECTL_VERSION=1.33.3 \
-    NODEJS_VERSION=24.5.0 \
-    PACKER_VERSION=1.14.1 \
-    RBENV_ROOT=/opt/rbenv \
-    RBENV_SHELL=bash \
-    RUBY_VERSION=3.4.1 \
-    SOPS_VERSION=3.10.2 \
-    STARSHIP_VERSION=1.23.0 \
-    TASK_VERSION=3.43.1 \
-    TENV_AUTO_INSTALL=true \
-    TENV_ROOT=/opt/tenv \
-    TENV_VERSION=1.2.0 \
-    TERRAFORM_CONFIG_INSPECT_VERSION=latest \
-    TERRAFORM_DOCS_VERSION=v0.20.0 \
-    TERRAFORM_VERSION=1.12.2 \
-    TFLINT_VERSION=0.58.1 \
-    TFSEC_VERSION=1.28.14 \
-    YQ_VERSION=4.47.1 \
-    ZOXIDE_VERSION=0.9.4
-
-ENV PYENV_ROOT=/opt/pyenv
-
-# Stable PATH for login/non-login shells
-ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
-ENV PATH=$PATH:/opt/bundle/bin:/root/.local/bin:/home/terrarium/.local/bin
-ENV HOME=/home/terrarium
-
-RUN echo "I am running on ${BUILDPLATFORM}, ${BUILDOS}, ${BUILDARCH}, ${BUILDVARIANT}, \
-    building for ${TARGETPLATFORM}, ${TARGETOS}, ${TARGETARCH}, ${TARGETVARIANT}."
-
-# OS update
-RUN . /etc/os-release && echo "Base image: $PRETTY_NAME" \
-    && dnf -y update \
-    && dnf clean all
-# Harden dnf against flaky mirrors / slow connections
-RUN printf '\nmax_parallel_downloads=10\nretries=10\n' >> /etc/dnf/dnf.conf
-
-# Enable CRB for UBI + EPEL; get jq/parallel
-RUN dnf -y install dnf-plugins-core \
-    && dnf config-manager --set-enabled ubi-9-codeready-builder-rpms \
-    && dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
-    && dnf -y install jq parallel \
-    && jq --version \
-    && dnf clean all
-
-# Runtime & build tools that DO exist in UBI repos
-ENV RUNTIME_PKGS="gcc gcc-c++ make git coreutils zlib zlib-devel unzip wget \
-    bzip2 bzip2-devel xz xz-devel sqlite sqlite-devel libffi libffi-devel \
-    openssl openssl-devel libuuid libyaml tk gdbm tar diffutils \
-    autoconf automake libtool procps which sudo"
-
-# IMPORTANT: UBI ships coreutils-single; swap to full coreutils before installing others
-RUN set -x \
-    && (dnf -q list installed coreutils-single >/dev/null 2>&1 && dnf -y swap coreutils-single coreutils || dnf -y install coreutils --allowerasing) \
-    && dnf -y install $RUNTIME_PKGS \
-    && dnf clean all
-
-# Robust downloader with retries for all big external fetches
-RUN cat >/usr/local/bin/fetch <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-curl --fail --silent --show-error --location \
-     --retry 5 --retry-all-errors --retry-delay 2 "$@"
-EOF
-RUN chmod +x /usr/local/bin/fetch
-
-# ---- Bring in languages, gems, and xorriso compiled on Rocky ----
-COPY --from=buildlang /opt/pyenv /opt/pyenv
-COPY --from=buildlang /opt/rbenv /opt/rbenv
-COPY --from=buildlang /opt/bundle /opt/bundle
-
-# Keep the Gemfile around at a stable path for our wrappers
-COPY Gemfile Gemfile.lock /opt/terrarium-gems/
-RUN chmod -R a+rX /opt/terrarium-gems
-
-# Ensure /opt/bundle matches /opt/terrarium-gems/Gemfile.lock (handles cache drift)
-ENV BUNDLE_SILENCE_ROOT_WARNING=1
-RUN set -eux; \
-    export RBENV_VERSION="${RUBY_VERSION}" \
-    BUNDLE_GEMFILE="/opt/terrarium-gems/Gemfile" \
-    BUNDLE_PATH="${GEM_HOME}" \
-    BUNDLE_FROZEN="true"; \
-    bundle check || bundle install --jobs=6 --retry=3; \
-    bundle clean --force
-
-# xorriso + its runtime libs (EPEL/UBI does not provide xorriso)
-COPY --from=buildlang /usr/bin/xorriso /usr/bin/xorriso
-COPY --from=buildlang /usr/lib64/libisoburn.so.* /usr/lib64/
-COPY --from=buildlang /usr/lib64/libisofs.so.*  /usr/lib64/
-COPY --from=buildlang /usr/lib64/libburn.so.*   /usr/lib64/
-RUN /sbin/ldconfig || /usr/sbin/ldconfig || true
-
-# ─── uv – ultra-fast dependency manager & Python launcher ───────────────────
-RUN fetch https://astral.sh/uv/install.sh | bash && uv --version
-
-# Configure PIP SSL validation (pyenv’s pip)
+# Configure PIP SSL validation
 RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
     && pip config list
 
-# ─── Azure CLI (install globally; avoids uv lockfile writes during tests) ───
-RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
-    && dnf -y install https://packages.microsoft.com/config/rhel/9/packages-microsoft-prod.rpm \
-    && dnf -y install azure-cli \
-    && az --version \
-    && dnf clean all
-
 # Install awscli2
 RUN TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64") \
-    && fetch -o awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-${TARGETOS}-${TARGETARCH_SYNONYM}.zip" \
+    && curl "https://awscli.amazonaws.com/awscli-exe-${TARGETOS}-${TARGETARCH_SYNONYM}.zip" -o "awscliv2.zip" \
     && unzip -qq awscliv2.zip \
     && ./aws/install \
-    && rm -rf aws awscliv2.zip \
+    && rm -f awscliv2.zip \
+    && rm -Rf ./aws \
     && /usr/local/bin/aws --version
 
-# Install AWS SAM CLI (zip for amd64, pip for arm64)
-RUN if [ "x${TARGETARCH}" = "xamd64" ]; then \
-    TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "use_pip"); \
-    fetch -o awssam.zip "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-${TARGETOS}-${TARGETARCH_SYNONYM}.zip"; \
-    unzip -qq -d awssam awssam.zip && ./awssam/install && rm -rf awssam awssam.zip; \
+# Install awssamcli
+RUN if [ x${TARGETARCH} == "xamd64" ]; then \
+    TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "use_pip") \
+    && curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-${TARGETOS}-${TARGETARCH_SYNONYM}.zip" -o "awssam.zip" \
+    && unzip -qq -d awssam awssam.zip \
+    && ./awssam/install \
+    && rm -f awssam.zip \
+    && rm -Rf ./awssam; \
     else \
-    pip install --no-cache-dir aws-sam-cli; \
+    pip3 install aws-sam-cli; \
     fi \
     && sam --version
 
-# Install Node + AWS CDK
-RUN TARGETARCH_SYNONYM_SHORT=$([[ "$TARGETARCH" == "amd64" ]] && echo "x64" || echo "arm64") \
-    && fetch -O "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz" \
-    && xzcat node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz | tar xpf - -C /opt/ \
-    && mv /opt/node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT} /opt/node \
-    && rm -f node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz \
-    && /opt/node/bin/npm install -g aws-cdk@${AWS_CDK_VERSION} \
-    && chown -R 1001:0 /opt/node && chmod +x /opt/node/bin/* \
-    && node --version && cdk --version
 
-# Install tenv + Terraform (single supported version)
+# Install aws cdk
+RUN TARGETARCH_SYNONYM_SHORT=$([[ "$TARGETARCH" == "amd64" ]] && echo "x64" || echo "arm64") \
+    && wget -q "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz" \
+    && xzcat node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz | tar xpf - -C /opt/ \
+    && rm -f node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz \
+    && mv /opt/node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT} /opt/node \
+    && /opt/node/bin/npm install -g aws-cdk \
+    && chown -R 1001:0 /opt/node && chmod +x /opt/node/bin/* \
+    && node --version \
+    && cdk --version
+
+# Install tenv
 RUN TENV_ARCH=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && dnf -y install "https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/tenv_v${TENV_VERSION}_${TENV_ARCH}.rpm" \
+    && yum install -y https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/tenv_v${TENV_VERSION}_${TENV_ARCH}.rpm \
     && tenv tf install ${TERRAFORM_VERSION} \
+    && tenv tf install ${TERRAFORM_VERSION_DEPRECATED} \
     && tenv tf use ${TERRAFORM_VERSION} \
     && terraform -version \
-    && chown -R 1001:0 "${TENV_ROOT}" && chmod -R 2775 "${TENV_ROOT}"
+    && tenv tf list \
+    && echo 'export PATH=$(/usr/bin/tenv update-path)' > /etc/profile.d/tenv.sh \
+    && chown -R 1001:0 "${TENV_ROOT}" \
+    && chmod -R 2775 "${TENV_ROOT}"
 
-# Safe tenv profile: prefer update-path if available, otherwise init
-RUN cat > /etc/profile.d/tenv.sh <<'EOF'
-# Safe tenv PATH integration. Never clobber PATH.
-if command -v tenv >/dev/null 2>&1; then
-  if tenv --help 2>&1 | grep -q 'update-path'; then
-    TENV_NEW_PATH="$((/usr/bin/tenv update-path) 2>/dev/null || true)"
-    if [ -n "$TENV_NEW_PATH" ]; then
-      case ":$PATH:" in *":$TENV_NEW_PATH:"*) : ;; *) PATH="$TENV_NEW_PATH:$PATH" ;; esac
-    fi
-  elif tenv --help 2>&1 | grep -q 'init'; then
-    eval "$(/usr/bin/tenv init - bash 2>/dev/null)" || true
-  fi
-fi
-export PATH
-EOF
-
-# Packer
+# Install tflint
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && fetch -o /tmp/packer.zip "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
-    && unzip -qq /tmp/packer.zip -d /usr/local/bin packer \
-    && rm -f /tmp/packer.zip \
+    && wget -q -O /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TARGETARCH_SYNONYM_SHORT2}.zip" \
+    && unzip /tmp/tflint.zip -d /usr/local/bin \
+    && rm -rf /tmp/tflint.zip \
+    && tflint --version
+
+# Install Packer
+RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
+    && wget -q -O /tmp/packer.zip "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
+    && unzip /tmp/packer.zip -d /usr/local/bin packer \
+    && rm -rf /tmp/packer.zip \
     && packer --version
 
-# Consul
+## Install consul-cli
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && fetch -o /tmp/consul.zip "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
-    && unzip -qq /tmp/consul.zip -d /usr/local/bin consul \
+    && wget -q -O /tmp/consul.zip -q "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
+    && unzip /tmp/consul.zip -d /usr/local/bin consul \
     && rm -f /tmp/consul.zip \
     && chmod +x /usr/local/bin/consul \
     && /usr/local/bin/consul -version
 
-# terraform-config-inspect (support "latest" tag)
-RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64"); \
-    if [ "${TERRAFORM_CONFIG_INSPECT_VERSION}" = "latest" ]; then \
-    TCI_TAG="$(curl -fsSL https://api.github.com/repos/nichtraunzer/terraform-config-inspect/releases/latest | jq -r .tag_name)"; \
-    TCI_VER="${TCI_TAG#v}"; \
-    else \
-    TCI_TAG="v${TERRAFORM_CONFIG_INSPECT_VERSION}"; \
-    TCI_VER="${TERRAFORM_CONFIG_INSPECT_VERSION#v}"; \
-    fi; \
-    curl -fsSLo /tmp/terraform-config-inspect.tar.gz \
-    "https://github.com/nichtraunzer/terraform-config-inspect/releases/download/${TCI_TAG}/terraform-config-inspect_${TCI_VER}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
+# Install terraform-config-inspect
+RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
+    && wget -q -O /tmp/terraform-config-inspect.tar.gz https://github.com/nichtraunzer/terraform-config-inspect/releases/download/v${TERRAFORM_CONFIG_INSPECT_VERSION}/terraform-config-inspect_${TERRAFORM_CONFIG_INSPECT_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
     && tar zxpf /tmp/terraform-config-inspect.tar.gz -C /usr/local/bin/ terraform-config-inspect \
     && rm -f /tmp/terraform-config-inspect.tar.gz \
     && chmod 755 /usr/local/bin/terraform-config-inspect \
     && /usr/local/bin/terraform-config-inspect
 
-# Terraform Docs
+# Install Terraform Docs
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && fetch -o /tmp/terraform-docs.tar.gz "https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
+    && wget -q -O /tmp/terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
     && tar zxpf /tmp/terraform-docs.tar.gz -C /usr/local/bin/ terraform-docs \
     && rm -f /tmp/terraform-docs.tar.gz \
     && chmod +x /usr/local/bin/terraform-docs \
     && /usr/local/bin/terraform-docs --help
 
-# tflint
-RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && fetch -o /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TARGETARCH_SYNONYM_SHORT2}.zip" \
-    && unzip -qq /tmp/tflint.zip -d /usr/local/bin \
-    && rm -f /tmp/tflint.zip \
-    && tflint --version
-
-# tfsec
-RUN ARCH=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && fetch -o /usr/local/bin/tfsec \
-    "https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-${ARCH}" \
-    && chmod +x /usr/local/bin/tfsec \
-    && tfsec --version
-
-# sops + age
+# Install mozilla/sops and AGE
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && TARGETARCH_SYNONYM_SHORT3=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64") \
-    && dnf -y install "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.${TARGETARCH_SYNONYM_SHORT3}.rpm" \
-    && fetch -o /tmp/age.tar.gz "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
+    && dnf install -y https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.${TARGETARCH_SYNONYM_SHORT3}.rpm \
+    && wget -q -O /tmp/age.tar.gz https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
     && tar zxpf /tmp/age.tar.gz --strip-components=1 -C /usr/local/bin age/age age/age-keygen \
     && rm -f /tmp/age.tar.gz \
     && /usr/bin/sops --version \
     && /usr/local/bin/age --version \
     && dnf clean all
 
-# starship & zoxide
-RUN fetch -o /tmp/starship.sh https://starship.rs/install.sh \
+# Install starship and zoxide
+RUN TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64") \
+    && wget -q -O /tmp/starship.sh https://starship.rs/install.sh \
     && chmod +x /tmp/starship.sh \
     && /tmp/starship.sh --yes \
     && rm -f /tmp/starship.sh \
-    && fetch -o /tmp/zoxide.sh https://webinstall.dev/zoxide \
+    && wget -q -O /tmp/zoxide.sh https://webinstall.dev/zoxide \
     && chmod +x /tmp/zoxide.sh \
-    && /tmp/zoxide.sh && rm -f /tmp/zoxide.sh
+    && /tmp/zoxide.sh \
+    && rm -f /tmp/zoxide.sh
 
-# Go (toolchain tarball) + go-task
+# Install GO
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && fetch -o /tmp/go.tar.gz "https://golang.org/dl/go${GO_VERSION}.${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
-    && tar -C /usr/local -xzf /tmp/go.tar.gz && rm -f /tmp/go.tar.gz
-ENV PATH=$PATH:/usr/local/go/bin
-RUN fetch https://taskfile.dev/install.sh | sh -s -- -d v${TASK_VERSION} \
+    && wget -q -O /tmp/go.tar.gz https://golang.org/dl/go${GO_VERSION}.${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && rm -f /tmp/go.tar.gz
+
+# Install go-task
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d v${TASK_VERSION} \
     && task --version
 
-# yq
+# Install yq
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && fetch -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH_SYNONYM_SHORT2}" \
+    && wget -q -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH_SYNONYM_SHORT2} \
     && chmod +x /usr/local/bin/yq \
     && /usr/local/bin/yq --version
 
@@ -332,66 +231,86 @@ RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" |
     && rm -f /tmp/helm.tar.gz \
     && helm version
 
-# Ownerships & dirs
-RUN chown -R 1001:0 ${HOME} && chmod -R g+rw ${HOME} \
-    && mkdir -p ${GEM_HOME} && chmod 2770 ${GEM_HOME} \
-    && chown -R 1001:0 ${GEM_HOME} && chmod -R g+rw ${GEM_HOME} \
+ENV PATH=$PATH:/usr/local/go/bin
+
+RUN chown -R 1001:0 ${HOME} \
+    && chmod -R g+rw ${HOME} \
+    && mkdir -p ${GEM_HOME} \
+    && chmod 2770 ${GEM_HOME}
+
+RUN chown -R 1001:0 ${GEM_HOME} \
+    && chmod -R g+rw ${GEM_HOME} \
     && ls -lisa ${HOME} ${GEM_HOME}
 
-# ---- Kitchen & Cinc wrappers (MANDATORY) -----------------------------------
-RUN install -d -m 0755 /usr/local/bin
+# setup ruby env and bundler gems
+# RUBY https://syslint.com/blog/tutorial/how-to-install-ruby-on-rails-with-rbenv-on-centos-7-or-rhel-7/
+RUN cd /opt \
+    && umask 0002 \
+    && git clone https://github.com/rbenv/rbenv.git /opt/rbenv \
+    && echo 'export PATH="/opt/rbenv/shims:/opt/rbenv/bin:$PATH"' >> ~/.bash_profile \
+    && echo 'eval "$(rbenv init -)"' >> ~/.bash_profile \
+    && source ~/.bash_profile \
+    && git clone https://github.com/rbenv/ruby-build.git /opt/rbenv/plugins/ruby-build \
+    && echo 'export PATH="/opt/rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bash_profile \
+    && source ~/.bash_profile \
+    && rbenv install ${RUBY_VERSION} \
+    && rbenv global ${RUBY_VERSION} \
+    && gem install bundler -v ${BUNDLER_VERSION} \
+    && RBENV_VERSION=${RUBY_VERSION} gem install bundler -v ${BUNDLER_VERSION} \
+    && bundle config default ${BUNDLER_VERSION} \
+    && RBENV_VERSION=${RUBY_VERSION} bundle config default ${BUNDLER_VERSION} \
+    && bundle config set --global path ${GEM_HOME} \
+    && RBENV_VERSION=${RUBY_VERSION} bundle config set --global path ${GEM_HOME}
 
-# kitchen wrapper
-RUN cat >/usr/local/bin/kitchen <<'EOF'
-#!/usr/bin/env bash
-export BUNDLE_GEMFILE=/opt/terrarium-gems/Gemfile
-export BUNDLE_PATH=/opt/bundle
-exec /opt/rbenv/shims/bundle exec kitchen "$@"
-EOF
-RUN chmod +x /usr/local/bin/kitchen
+RUN source ~/.bash_profile \
+    && rbenv install ${RUBY_VERSION_DEPRECATED} \
+    && RBENV_VERSION=${RUBY_VERSION_DEPRECATED} gem install bundler -v ${BUNDLER_VERSION_DEPRECATED} \
+    && rbenv install -L
 
-# cinc-auditor wrapper
-RUN cat >/usr/local/bin/cinc-auditor <<'EOF'
-#!/usr/bin/env bash
-export BUNDLE_GEMFILE=/opt/terrarium-gems/Gemfile
-export BUNDLE_PATH=/opt/bundle
-exec /opt/rbenv/shims/bundle exec cinc-auditor "$@"
-EOF
-RUN chmod +x /usr/local/bin/cinc-auditor
+COPY Gemfile Gemfile.lock ${GEM_HOME}/
 
-# Smoke check that both wrappers work at build time
-RUN RBENV_VERSION=${RUBY_VERSION} \
-    BUNDLE_GEMFILE=/opt/terrarium-gems/Gemfile \
-    BUNDLE_PATH=${GEM_HOME} \
-    bundle check
-RUN kitchen --version && cinc-auditor version
+RUN source ~/.bash_profile \
+    && RBENV_VERSION=${RUBY_VERSION} ruby --version \
+    && RBENV_VERSION=${RUBY_VERSION_DEPRECATED} ruby --version \
+    && cd ${GEM_HOME} \
+    && BUNDLE_SILENCE_ROOT_WARNING=true bundle install --full-index --jobs=6 \
+    && bundle binstubs --all \
+    && bundle binstubs bundler --force \
+    && rm -Rf ${HOME}/.bundle/cache
 
-# bats-core for tests (single install)
-RUN set -eux; \
-    rm -rf /opt/bats-core; \
-    git clone --depth 1 --branch "v${BATS_CORE_VERSION}" \
-    https://github.com/bats-core/bats-core.git /opt/bats-core; \
-    /opt/bats-core/install.sh /usr/local; \
-    rm -rf /opt/bats-core; \
-    bats --version
-
+# Install test dependencies to allow for testing of output image
+# --- add latest bats-core (one small layer, ~1 MiB) ---
+RUN git clone --depth 1 --branch v1.11.0 \
+    https://github.com/bats-core/bats-core.git /opt/bats-core \
+    && /opt/bats-core/install.sh /usr/local \
+    && bats --version
 COPY tests /home/terrarium/tests
+
+
 
 WORKDIR $HOME
 CMD ["/bin/bash", "-i", "-l"]
 
-# ================= Stage 2 — test =================
+################  Stage 2 — test  ###################
 FROM builder AS test
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN install -d -m 0755 /home/terrarium/tests/test_helper \
-    && rm -rf /home/terrarium/tests/test_helper/bats-support /home/terrarium/tests/test_helper/bats-assert \
-    && git clone --depth 1 https://github.com/bats-core/bats-support.git /home/terrarium/tests/test_helper/bats-support \
-    && git clone --depth 1 https://github.com/bats-core/bats-assert.git   /home/terrarium/tests/test_helper/bats-assert
+
+# bring in the official bats-support & bats-assert helpers
+RUN git clone https://github.com/bats-core/bats-support.git /home/terrarium/tests/test_helper/bats-support \
+    && git clone https://github.com/bats-core/bats-assert.git   /home/terrarium/tests/test_helper/bats-assert
+
+# make all tests (and helpers) executable
 RUN find /home/terrarium/tests -type f -name "*.bats" -exec chmod +x {} \;
+
+# ---- give UID 1001 a real name (optional hardening) ----
 RUN useradd -u 1001 terrarium
 USER 1001:0
+
+# now run them, emitting a proper JUnit XML report
 RUN bats --report-formatter junit /home/terrarium/tests --output /home/terrarium --jobs $(nproc)
 
-# ================= Stage 3 — final =================
+# Make sure test files under /home/terrarium/tests are owned by the user and are executable
+################  Stage 3 — final runtime image  ####
+# IMPORTANT: Do not copy bats or tests.
 FROM builder AS final
+# (Optional) clean caches, strip docs
 CMD ["/bin/bash"]

--- a/terraform/docker/Dockerfile.terrarium
+++ b/terraform/docker/Dockerfile.terrarium
@@ -242,6 +242,9 @@ RUN chown -R 1001:0 ${GEM_HOME} \
     && chmod -R g+rw ${GEM_HOME} \
     && ls -lisa ${HOME} ${GEM_HOME}
 
+# ─── OpenSSL build prereqs for ruby-build on RHEL/Rocky ───────────────
+RUN dnf -y install perl-IPC-Cmd && dnf clean all
+
 # setup ruby env and bundler gems
 # RUBY https://syslint.com/blog/tutorial/how-to-install-ruby-on-rails-with-rbenv-on-centos-7-or-rhel-7/
 RUN cd /opt \

--- a/terraform/docker/Dockerfile.terrarium
+++ b/terraform/docker/Dockerfile.terrarium
@@ -1,303 +1,397 @@
-FROM rockylinux/rockylinux:8 AS builder
-
-LABEL maintainer="Erhard Wais <erhard.wais@boehringer-ingelheim.com>, Josef Hartmann <josef.hartmann@boehringer-ingelheim.com>"
-
-ARG TARGETPLATFORM TARGETOS TARGETARCH TARGETVARIANT BUILDPLATFORM BUILDOS BUILDARCH BUILDVARIANT
+# --------- Global args used across stages ---------
 ARG PYTHON_VERSION=3.12.11
+ARG RUBY_VERSION=3.4.1
+ARG BUNDLER_VERSION=2.7.1
+ARG GEM_HOME=/opt/bundle
+ARG BATS_CORE_VERSION=1.11.0
 
-#ENV TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64")
-#ENV TARGETARCH_SYNONYM_SHORT=$([[ "$TARGETARCH" == "amd64" ]] && echo "x64" || echo "arm64")
+# ================= Stage 0 — buildlang (compile on Rocky 9) =================
+FROM rockylinux:9 AS buildlang
+ARG PYTHON_VERSION RUBY_VERSION BUNDLER_VERSION GEM_HOME
 
-ENV TERRAFORM_VERSION=1.9.4 \
-    TERRAFORM_VERSION_DEPRECATED=1.4.6 \
-    TERRAFORM_CONFIG_INSPECT_VERSION=0.2.0 \
-    TERRAFORM_DOCS_VERSION=v0.19.0 \
-    RUBY_VERSION=3.3.4 \
-    RUBY_VERSION_DEPRECATED=3.2.2 \
-    PACKER_VERSION=1.11.2 \
-    CONSUL_VERSION=1.19.1 \
-    TENV_VERSION=3.0.0 \
-    TENV_AUTO_INSTALL=true \
-    TENV_ROOT=/opt/tenv \
-    TFLINT_VERSION=0.52.0 \
-    NODEJS_VERSION=20.16.0 \
-    BUNDLER_VERSION=2.5.17 \
-    BUNDLER_VERSION_DEPRECATED=2.4.13 \
-    GEM_HOME=/opt/bundle \
+ENV PYENV_ROOT=/opt/pyenv \
     RBENV_ROOT=/opt/rbenv \
-    RBENV_SHELL=bash \
-    SOPS_VERSION=3.9.0 \
-    AGE_VERSION=1.2.0 \
-    KUBECTL_VERSION=1.30 \
-    HELM_VERSION=3.14.0 \
-    STARSHIP_VERSION=1.20.1 \
-    ZOXIDE_VERSION=0.9.4 \
-    GO_VERSION=1.24.5 \
-    TASK_VERSION=3.38.0 \
-    YQ_VERSION=4.44.3
+    GEM_HOME=${GEM_HOME}
+# Put shims first so compilers/env see the right python/ruby
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${RBENV_ROOT}/shims:${RBENV_ROOT}/bin:$PATH
 
-ENV PYTHON_VERSION=${PYTHON_VERSION}
-ENV PYENV_ROOT=/opt/pyenv
-
-ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline readline-devel unzip wget \
-    bzip2-devel xz-devel tk-devel gdbm-devel libuuid-devel \
-    libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl diffutils libyaml-devel sqlite-devel xz procps which sudo xorriso"
-
-# put pyenv shims ahead of everything else
-ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
-# add gem executables and user-local bin (zoxide) to every shell
-ENV PATH=$PATH:/opt/bundle/bin:/root/.local/bin:/home/terrarium/.local/bin
-ENV HOME=/home/terrarium
-
-COPY python_requirements /tmp/requirements.txt
-
-RUN echo "I am running on ${BUILDPLATFORM}, ${BUILDOS}, ${BUILDARCH}, ${BUILDVARIANT}, \
-    building for ${TARGETPLATFORM}, ${TARGETOS}, ${TARGETARCH}, ${TARGETVARIANT}."
-
-# Updates OS packages
-RUN dnf install -y redhat-lsb-core \
-    && lsb_release -d \
-    && dnf update -y \
-    && lsb_release -d \
+# Full toolchain + all -devel libs needed by CPython/Ruby & native gems
+# NOTE: don't install 'curl' here to avoid conflict with curl-minimal on EL9.
+RUN dnf -y update \
+    && dnf -y install dnf-plugins-core \
+    && dnf config-manager --set-enabled crb \
+    && dnf -y groupinstall "Development Tools" \
+    && dnf -y install \
+    git wget tar patch which sudo procps diffutils xz unzip \
+    gcc gcc-c++ make autoconf automake libtool bison \
+    zlib zlib-devel bzip2 bzip2-devel xz xz-devel \
+    openssl openssl-devel libffi libffi-devel \
+    sqlite sqlite-devel libyaml libyaml-devel \
+    readline readline-devel gdbm gdbm-devel libuuid libuuid-devel \
+    tk tk-devel \
+    xorriso \
     && dnf clean all
 
-# Install jq
-RUN dnf install -y epel-release \
-    && crb enable \
-    && dnf install -y jq parallel \
-    && jq -Version \
-    && dnf clean all
-
-RUN set -x \
-    && dnf install -y $INSTALL_PKGS \
-    && dnf clean all
-
-# ─── PYTHON via pyenv ────────────────────────────────────────────────────────
+# ---- pyenv & Python ----
 RUN umask 0002 \
     && git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT} \
     && git clone https://github.com/pyenv/pyenv-update.git ${PYENV_ROOT}/plugins/pyenv-update \
     && ${PYENV_ROOT}/bin/pyenv install ${PYTHON_VERSION} \
     && ${PYENV_ROOT}/bin/pyenv global  ${PYTHON_VERSION} \
-    && python  --version && pip --version
+    && python --version && pip --version
 
-# ─── Python user‑level libraries ─────────────────────────────────────────────
-RUN python -m pip install --upgrade pip setuptools \
-    && python -m pip install -r /tmp/requirements.txt \
-    && rm -f /tmp/requirements
+# ---- rbenv & Ruby + Bundler (single supported version) ----
+RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_ROOT} \
+    && git clone https://github.com/rbenv/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build \
+    && ${RBENV_ROOT}/bin/rbenv install ${RUBY_VERSION} \
+    && ${RBENV_ROOT}/bin/rbenv global ${RUBY_VERSION} \
+    && RBENV_VERSION=${RUBY_VERSION} gem install bundler -v ${BUNDLER_VERSION}
 
+# Install the repo Gemfile into /opt/bundle (no direct gem installs of kitchen/cinc!)
+COPY Gemfile Gemfile.lock /tmp/gems/
+RUN RBENV_VERSION=${RUBY_VERSION} bundle config set --global path ${GEM_HOME} \
+    && RBENV_VERSION=${RUBY_VERSION} bash -lc "cd /tmp/gems \
+    && BUNDLE_SILENCE_ROOT_WARNING=true bundle install --full-index --jobs=6 \
+    && bundle binstubs bundler --force" \
+    && rm -rf /root/.bundle/cache
 
+# ================= Stage 1 — builder (UBI 9) =================
+FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# ─── uv – ultra‑fast dependency manager & Python launcher ───────────────────
-RUN curl -Ls https://astral.sh/uv/install.sh | bash \
-    && uv --version
+LABEL maintainer="Erhard Wais <erhard.wais@boehringer-ingelheim.com>, Josef Hartmann <josef.hartmann@boehringer-ingelheim.com>"
 
+ARG TARGETPLATFORM TARGETOS TARGETARCH TARGETVARIANT BUILDPLATFORM BUILDOS BUILDARCH BUILDVARIANT
+ARG PYTHON_VERSION
+ARG GEM_HOME
+ARG BATS_CORE_VERSION
 
-# Configure PIP SSL validation
+# Tool versions (deprecated pins removed)
+ENV AGE_VERSION=1.2.1 \
+    AWS_CDK_VERSION=2.1024.0 \
+    BUNDLER_VERSION=2.7.1 \
+    CONSUL_VERSION=1.21.3 \
+    GEM_HOME=/opt/bundle \
+    GO_VERSION=1.24.6 \
+    HELM_VERSION=3.18.4 \
+    KUBECTL_VERSION=1.33.3 \
+    NODEJS_VERSION=24.5.0 \
+    PACKER_VERSION=1.14.1 \
+    RBENV_ROOT=/opt/rbenv \
+    RBENV_SHELL=bash \
+    RUBY_VERSION=3.4.1 \
+    SOPS_VERSION=3.10.2 \
+    STARSHIP_VERSION=1.23.0 \
+    TASK_VERSION=3.43.1 \
+    TENV_AUTO_INSTALL=true \
+    TENV_ROOT=/opt/tenv \
+    TENV_VERSION=1.2.0 \
+    TERRAFORM_CONFIG_INSPECT_VERSION=latest \
+    TERRAFORM_DOCS_VERSION=v0.20.0 \
+    TERRAFORM_VERSION=1.12.2 \
+    TFLINT_VERSION=0.58.1 \
+    TFSEC_VERSION=1.28.14 \
+    YQ_VERSION=4.47.1 \
+    ZOXIDE_VERSION=0.9.4
+
+ENV PYENV_ROOT=/opt/pyenv
+
+# Stable PATH for login/non-login shells
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
+ENV PATH=$PATH:/opt/bundle/bin:/root/.local/bin:/home/terrarium/.local/bin
+ENV HOME=/home/terrarium
+
+RUN echo "I am running on ${BUILDPLATFORM}, ${BUILDOS}, ${BUILDARCH}, ${BUILDVARIANT}, \
+    building for ${TARGETPLATFORM}, ${TARGETOS}, ${TARGETARCH}, ${TARGETVARIANT}."
+
+# OS update
+RUN . /etc/os-release && echo "Base image: $PRETTY_NAME" \
+    && dnf -y update \
+    && dnf clean all
+# Harden dnf against flaky mirrors / slow connections
+RUN printf '\nmax_parallel_downloads=10\nretries=10\n' >> /etc/dnf/dnf.conf
+
+# Enable CRB for UBI + EPEL; get jq/parallel
+RUN dnf -y install dnf-plugins-core \
+    && dnf config-manager --set-enabled ubi-9-codeready-builder-rpms \
+    && dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
+    && dnf -y install jq parallel \
+    && jq --version \
+    && dnf clean all
+
+# Runtime & build tools that DO exist in UBI repos
+ENV RUNTIME_PKGS="gcc gcc-c++ make git coreutils zlib zlib-devel unzip wget \
+    bzip2 bzip2-devel xz xz-devel sqlite sqlite-devel libffi libffi-devel \
+    openssl openssl-devel libuuid libyaml tk gdbm tar diffutils \
+    autoconf automake libtool procps which sudo"
+
+# IMPORTANT: UBI ships coreutils-single; swap to full coreutils before installing others
+RUN set -x \
+    && (dnf -q list installed coreutils-single >/dev/null 2>&1 && dnf -y swap coreutils-single coreutils || dnf -y install coreutils --allowerasing) \
+    && dnf -y install $RUNTIME_PKGS \
+    && dnf clean all
+
+# Robust downloader with retries for all big external fetches
+RUN cat >/usr/local/bin/fetch <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+curl --fail --silent --show-error --location \
+     --retry 5 --retry-all-errors --retry-delay 2 "$@"
+EOF
+RUN chmod +x /usr/local/bin/fetch
+
+# ---- Bring in languages, gems, and xorriso compiled on Rocky ----
+COPY --from=buildlang /opt/pyenv /opt/pyenv
+COPY --from=buildlang /opt/rbenv /opt/rbenv
+COPY --from=buildlang /opt/bundle /opt/bundle
+
+# Keep the Gemfile around at a stable path for our wrappers
+COPY Gemfile Gemfile.lock /opt/terrarium-gems/
+RUN chmod -R a+rX /opt/terrarium-gems
+
+# Ensure /opt/bundle matches /opt/terrarium-gems/Gemfile.lock (handles cache drift)
+ENV BUNDLE_SILENCE_ROOT_WARNING=1
+RUN set -eux; \
+    export RBENV_VERSION="${RUBY_VERSION}" \
+    BUNDLE_GEMFILE="/opt/terrarium-gems/Gemfile" \
+    BUNDLE_PATH="${GEM_HOME}" \
+    BUNDLE_FROZEN="true"; \
+    bundle check || bundle install --jobs=6 --retry=3; \
+    bundle clean --force
+
+# xorriso + its runtime libs (EPEL/UBI does not provide xorriso)
+COPY --from=buildlang /usr/bin/xorriso /usr/bin/xorriso
+COPY --from=buildlang /usr/lib64/libisoburn.so.* /usr/lib64/
+COPY --from=buildlang /usr/lib64/libisofs.so.*  /usr/lib64/
+COPY --from=buildlang /usr/lib64/libburn.so.*   /usr/lib64/
+RUN /sbin/ldconfig || /usr/sbin/ldconfig || true
+
+# ─── uv – ultra-fast dependency manager & Python launcher ───────────────────
+RUN fetch https://astral.sh/uv/install.sh | bash && uv --version
+
+# Configure PIP SSL validation (pyenv’s pip)
 RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
     && pip config list
 
+# ─── Azure CLI (install globally; avoids uv lockfile writes during tests) ───
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
+    && dnf -y install https://packages.microsoft.com/config/rhel/9/packages-microsoft-prod.rpm \
+    && dnf -y install azure-cli \
+    && az --version \
+    && dnf clean all
+
 # Install awscli2
 RUN TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64") \
-    && curl "https://awscli.amazonaws.com/awscli-exe-${TARGETOS}-${TARGETARCH_SYNONYM}.zip" -o "awscliv2.zip" \
+    && fetch -o awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-${TARGETOS}-${TARGETARCH_SYNONYM}.zip" \
     && unzip -qq awscliv2.zip \
     && ./aws/install \
-    && rm -f awscliv2.zip \
-    && rm -Rf ./aws \
+    && rm -rf aws awscliv2.zip \
     && /usr/local/bin/aws --version
 
-# Install awssamcli
-RUN if [ x${TARGETARCH} == "xamd64" ]; then \
-    TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "use_pip") \
-    && curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-${TARGETOS}-${TARGETARCH_SYNONYM}.zip" -o "awssam.zip" \
-    && unzip -qq -d awssam awssam.zip \
-    && ./awssam/install \
-    && rm -f awssam.zip \
-    && rm -Rf ./awssam; \
+# Install AWS SAM CLI (zip for amd64, pip for arm64)
+RUN if [ "x${TARGETARCH}" = "xamd64" ]; then \
+    TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "use_pip"); \
+    fetch -o awssam.zip "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-${TARGETOS}-${TARGETARCH_SYNONYM}.zip"; \
+    unzip -qq -d awssam awssam.zip && ./awssam/install && rm -rf awssam awssam.zip; \
     else \
-    pip3 install aws-sam-cli; \
+    pip install --no-cache-dir aws-sam-cli; \
     fi \
     && sam --version
 
-
-# Install aws cdk
+# Install Node + AWS CDK
 RUN TARGETARCH_SYNONYM_SHORT=$([[ "$TARGETARCH" == "amd64" ]] && echo "x64" || echo "arm64") \
-    && wget -q "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz" \
+    && fetch -O "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz" \
     && xzcat node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz | tar xpf - -C /opt/ \
-    && rm -f node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz \
     && mv /opt/node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT} /opt/node \
-    && /opt/node/bin/npm install -g aws-cdk \
+    && rm -f node-v${NODEJS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT}.tar.xz \
+    && /opt/node/bin/npm install -g aws-cdk@${AWS_CDK_VERSION} \
     && chown -R 1001:0 /opt/node && chmod +x /opt/node/bin/* \
-    && node --version \
-    && cdk --version
+    && node --version && cdk --version
 
-# Install tenv
+# Install tenv + Terraform (single supported version)
 RUN TENV_ARCH=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && yum install -y https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/tenv_v${TENV_VERSION}_${TENV_ARCH}.rpm \
+    && dnf -y install "https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/tenv_v${TENV_VERSION}_${TENV_ARCH}.rpm" \
     && tenv tf install ${TERRAFORM_VERSION} \
-    && tenv tf install ${TERRAFORM_VERSION_DEPRECATED} \
     && tenv tf use ${TERRAFORM_VERSION} \
     && terraform -version \
-    && tenv tf list \
-    && echo 'export PATH=$(/usr/bin/tenv update-path)' > /etc/profile.d/tenv.sh \
-    && chown -R 1001:0 "${TENV_ROOT}" \
-    && chmod -R 2775 "${TENV_ROOT}"
+    && chown -R 1001:0 "${TENV_ROOT}" && chmod -R 2775 "${TENV_ROOT}"
 
-# Install tflint
-RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && wget -q -O /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TARGETARCH_SYNONYM_SHORT2}.zip" \
-    && unzip /tmp/tflint.zip -d /usr/local/bin \
-    && rm -rf /tmp/tflint.zip \
-    && tflint --version
+# Safe tenv profile: prefer update-path if available, otherwise init
+RUN cat > /etc/profile.d/tenv.sh <<'EOF'
+# Safe tenv PATH integration. Never clobber PATH.
+if command -v tenv >/dev/null 2>&1; then
+  if tenv --help 2>&1 | grep -q 'update-path'; then
+    TENV_NEW_PATH="$((/usr/bin/tenv update-path) 2>/dev/null || true)"
+    if [ -n "$TENV_NEW_PATH" ]; then
+      case ":$PATH:" in *":$TENV_NEW_PATH:"*) : ;; *) PATH="$TENV_NEW_PATH:$PATH" ;; esac
+    fi
+  elif tenv --help 2>&1 | grep -q 'init'; then
+    eval "$(/usr/bin/tenv init - bash 2>/dev/null)" || true
+  fi
+fi
+export PATH
+EOF
 
-# Install Packer
+# Packer
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && wget -q -O /tmp/packer.zip "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
-    && unzip /tmp/packer.zip -d /usr/local/bin packer \
-    && rm -rf /tmp/packer.zip \
+    && fetch -o /tmp/packer.zip "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
+    && unzip -qq /tmp/packer.zip -d /usr/local/bin packer \
+    && rm -f /tmp/packer.zip \
     && packer --version
 
-## Install consul-cli
+# Consul
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && wget -q -O /tmp/consul.zip -q "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
-    && unzip /tmp/consul.zip -d /usr/local/bin consul \
+    && fetch -o /tmp/consul.zip "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.zip" \
+    && unzip -qq /tmp/consul.zip -d /usr/local/bin consul \
     && rm -f /tmp/consul.zip \
     && chmod +x /usr/local/bin/consul \
     && /usr/local/bin/consul -version
 
-# Install terraform-config-inspect
-RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && wget -q -O /tmp/terraform-config-inspect.tar.gz https://github.com/nichtraunzer/terraform-config-inspect/releases/download/v${TERRAFORM_CONFIG_INSPECT_VERSION}/terraform-config-inspect_${TERRAFORM_CONFIG_INSPECT_VERSION}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
+# terraform-config-inspect (support "latest" tag)
+RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64"); \
+    if [ "${TERRAFORM_CONFIG_INSPECT_VERSION}" = "latest" ]; then \
+    TCI_TAG="$(curl -fsSL https://api.github.com/repos/nichtraunzer/terraform-config-inspect/releases/latest | jq -r .tag_name)"; \
+    TCI_VER="${TCI_TAG#v}"; \
+    else \
+    TCI_TAG="v${TERRAFORM_CONFIG_INSPECT_VERSION}"; \
+    TCI_VER="${TERRAFORM_CONFIG_INSPECT_VERSION#v}"; \
+    fi; \
+    curl -fsSLo /tmp/terraform-config-inspect.tar.gz \
+    "https://github.com/nichtraunzer/terraform-config-inspect/releases/download/${TCI_TAG}/terraform-config-inspect_${TCI_VER}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
     && tar zxpf /tmp/terraform-config-inspect.tar.gz -C /usr/local/bin/ terraform-config-inspect \
     && rm -f /tmp/terraform-config-inspect.tar.gz \
     && chmod 755 /usr/local/bin/terraform-config-inspect \
     && /usr/local/bin/terraform-config-inspect
 
-# Install Terraform Docs
+# Terraform Docs
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && wget -q -O /tmp/terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
+    && fetch -o /tmp/terraform-docs.tar.gz "https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
     && tar zxpf /tmp/terraform-docs.tar.gz -C /usr/local/bin/ terraform-docs \
     && rm -f /tmp/terraform-docs.tar.gz \
     && chmod +x /usr/local/bin/terraform-docs \
     && /usr/local/bin/terraform-docs --help
 
-# Install mozilla/sops and AGE
+# tflint
+RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
+    && fetch -o /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TARGETARCH_SYNONYM_SHORT2}.zip" \
+    && unzip -qq /tmp/tflint.zip -d /usr/local/bin \
+    && rm -f /tmp/tflint.zip \
+    && tflint --version
+
+# tfsec
+RUN ARCH=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
+    && fetch -o /usr/local/bin/tfsec \
+    "https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-${ARCH}" \
+    && chmod +x /usr/local/bin/tfsec \
+    && tfsec --version
+
+# sops + age
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && TARGETARCH_SYNONYM_SHORT3=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64") \
-    && dnf install -y https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.${TARGETARCH_SYNONYM_SHORT3}.rpm \
-    && wget -q -O /tmp/age.tar.gz https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
+    && dnf -y install "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.${TARGETARCH_SYNONYM_SHORT3}.rpm" \
+    && fetch -o /tmp/age.tar.gz "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
     && tar zxpf /tmp/age.tar.gz --strip-components=1 -C /usr/local/bin age/age age/age-keygen \
     && rm -f /tmp/age.tar.gz \
     && /usr/bin/sops --version \
     && /usr/local/bin/age --version \
     && dnf clean all
 
-# Install starship and zoxide
-RUN TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64") \
-    && wget -q -O /tmp/starship.sh https://starship.rs/install.sh \
+# starship & zoxide
+RUN fetch -o /tmp/starship.sh https://starship.rs/install.sh \
     && chmod +x /tmp/starship.sh \
     && /tmp/starship.sh --yes \
     && rm -f /tmp/starship.sh \
-    && wget -q -O /tmp/zoxide.sh https://webinstall.dev/zoxide \
+    && fetch -o /tmp/zoxide.sh https://webinstall.dev/zoxide \
     && chmod +x /tmp/zoxide.sh \
-    && /tmp/zoxide.sh \
-    && rm -f /tmp/zoxide.sh
+    && /tmp/zoxide.sh && rm -f /tmp/zoxide.sh
 
-# Install GO
+# Go (toolchain tarball) + go-task
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && wget -q -O /tmp/go.tar.gz https://golang.org/dl/go${GO_VERSION}.${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz \
-    && tar -C /usr/local -xzf /tmp/go.tar.gz \
-    && rm -f /tmp/go.tar.gz
-
-# Install go-task
-RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d v${TASK_VERSION} \
+    && fetch -o /tmp/go.tar.gz "https://golang.org/dl/go${GO_VERSION}.${TARGETOS}-${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz && rm -f /tmp/go.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin
+RUN fetch https://taskfile.dev/install.sh | sh -s -- -d v${TASK_VERSION} \
     && task --version
 
-# Install yq
+# yq
 RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
-    && wget -q -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH_SYNONYM_SHORT2} \
+    && fetch -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH_SYNONYM_SHORT2}" \
     && chmod +x /usr/local/bin/yq \
     && /usr/local/bin/yq --version
 
-ENV PATH=$PATH:/usr/local/go/bin
+# kubectl
+RUN curl -fsSLo /usr/local/bin/kubectl \
+    https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && kubectl version --client=true
 
-RUN chown -R 1001:0 ${HOME} \
-    && chmod -R g+rw ${HOME} \
-    && mkdir -p ${GEM_HOME} \
-    && chmod 2770 ${GEM_HOME}
+# helm
+RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
+    && curl -fsSLo /tmp/helm.tar.gz "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
+    && tar -zxvf /tmp/helm.tar.gz --strip-components=1 -C /usr/local/bin linux-${TARGETARCH_SYNONYM_SHORT2}/helm \
+    && rm -f /tmp/helm.tar.gz \
+    && helm version
 
-RUN chown -R 1001:0 ${GEM_HOME} \
-    && chmod -R g+rw ${GEM_HOME} \
+# Ownerships & dirs
+RUN chown -R 1001:0 ${HOME} && chmod -R g+rw ${HOME} \
+    && mkdir -p ${GEM_HOME} && chmod 2770 ${GEM_HOME} \
+    && chown -R 1001:0 ${GEM_HOME} && chmod -R g+rw ${GEM_HOME} \
     && ls -lisa ${HOME} ${GEM_HOME}
 
-# setup ruby env and bundler gems
-# RUBY https://syslint.com/blog/tutorial/how-to-install-ruby-on-rails-with-rbenv-on-centos-7-or-rhel-7/
-RUN cd /opt \
-    && umask 0002 \
-    && git clone https://github.com/rbenv/rbenv.git /opt/rbenv \
-    && echo 'export PATH="/opt/rbenv/shims:/opt/rbenv/bin:$PATH"' >> ~/.bash_profile \
-    && echo 'eval "$(rbenv init -)"' >> ~/.bash_profile \
-    && source ~/.bash_profile \
-    && git clone https://github.com/rbenv/ruby-build.git /opt/rbenv/plugins/ruby-build \
-    && echo 'export PATH="/opt/rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bash_profile \
-    && source ~/.bash_profile \
-    && rbenv install ${RUBY_VERSION} \
-    && rbenv global ${RUBY_VERSION} \
-    && gem install bundler -v ${BUNDLER_VERSION} \
-    && RBENV_VERSION=${RUBY_VERSION} gem install bundler -v ${BUNDLER_VERSION} \
-    && bundle config default ${BUNDLER_VERSION} \
-    && RBENV_VERSION=${RUBY_VERSION} bundle config default ${BUNDLER_VERSION} \
-    && bundle config set --global path ${GEM_HOME} \
-    && RBENV_VERSION=${RUBY_VERSION} bundle config set --global path ${GEM_HOME}
+# ---- Kitchen & Cinc wrappers (MANDATORY) -----------------------------------
+RUN install -d -m 0755 /usr/local/bin
 
-RUN source ~/.bash_profile \
-    && rbenv install ${RUBY_VERSION_DEPRECATED} \
-    && RBENV_VERSION=${RUBY_VERSION_DEPRECATED} gem install bundler -v ${BUNDLER_VERSION_DEPRECATED} \
-    && rbenv install -L
+# kitchen wrapper
+RUN cat >/usr/local/bin/kitchen <<'EOF'
+#!/usr/bin/env bash
+export BUNDLE_GEMFILE=/opt/terrarium-gems/Gemfile
+export BUNDLE_PATH=/opt/bundle
+exec /opt/rbenv/shims/bundle exec kitchen "$@"
+EOF
+RUN chmod +x /usr/local/bin/kitchen
 
-COPY Gemfile Gemfile.lock ${GEM_HOME}/
+# cinc-auditor wrapper
+RUN cat >/usr/local/bin/cinc-auditor <<'EOF'
+#!/usr/bin/env bash
+export BUNDLE_GEMFILE=/opt/terrarium-gems/Gemfile
+export BUNDLE_PATH=/opt/bundle
+exec /opt/rbenv/shims/bundle exec cinc-auditor "$@"
+EOF
+RUN chmod +x /usr/local/bin/cinc-auditor
 
-RUN source ~/.bash_profile \
-    && RBENV_VERSION=${RUBY_VERSION} ruby --version \
-    && RBENV_VERSION=${RUBY_VERSION_DEPRECATED} ruby --version \
-    && cd ${GEM_HOME} \
-    && BUNDLE_SILENCE_ROOT_WARNING=true bundle install --full-index --jobs=6 \
-    && bundle binstubs --all \
-    && bundle binstubs bundler --force \
-    && rm -Rf ${HOME}/.bundle/cache
+# Smoke check that both wrappers work at build time
+RUN RBENV_VERSION=${RUBY_VERSION} \
+    BUNDLE_GEMFILE=/opt/terrarium-gems/Gemfile \
+    BUNDLE_PATH=${GEM_HOME} \
+    bundle check
+RUN kitchen --version && cinc-auditor version
 
-# Install test dependencies to allow for testing of output image
-# --- add latest bats-core (one small layer, ~1 MiB) ---
-RUN git clone --depth 1 --branch v1.11.0 \
-    https://github.com/bats-core/bats-core.git /opt/bats-core \
-    && /opt/bats-core/install.sh /usr/local \
-    && bats --version
+# bats-core for tests (single install)
+RUN set -eux; \
+    rm -rf /opt/bats-core; \
+    git clone --depth 1 --branch "v${BATS_CORE_VERSION}" \
+    https://github.com/bats-core/bats-core.git /opt/bats-core; \
+    /opt/bats-core/install.sh /usr/local; \
+    rm -rf /opt/bats-core; \
+    bats --version
+
 COPY tests /home/terrarium/tests
-
-
 
 WORKDIR $HOME
 CMD ["/bin/bash", "-i", "-l"]
 
-################  Stage 2 — test  ###################
+# ================= Stage 2 — test =================
 FROM builder AS test
-
-# bring in the official bats-support & bats-assert helpers
-RUN git clone https://github.com/bats-core/bats-support.git /home/terrarium/tests/test_helper/bats-support \
-    && git clone https://github.com/bats-core/bats-assert.git   /home/terrarium/tests/test_helper/bats-assert
-
-# make all tests (and helpers) executable
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN install -d -m 0755 /home/terrarium/tests/test_helper \
+    && rm -rf /home/terrarium/tests/test_helper/bats-support /home/terrarium/tests/test_helper/bats-assert \
+    && git clone --depth 1 https://github.com/bats-core/bats-support.git /home/terrarium/tests/test_helper/bats-support \
+    && git clone --depth 1 https://github.com/bats-core/bats-assert.git   /home/terrarium/tests/test_helper/bats-assert
 RUN find /home/terrarium/tests -type f -name "*.bats" -exec chmod +x {} \;
-
-# ---- give UID 1001 a real name (optional hardening) ----
 RUN useradd -u 1001 terrarium
 USER 1001:0
-
-# now run them, emitting a proper JUnit XML report
 RUN bats --report-formatter junit /home/terrarium/tests --output /home/terrarium --jobs $(nproc)
 
-# Make sure test files under /home/terrarium/tests are owned by the user and are executable
-################  Stage 3 — final runtime image  ####
-# IMPORTANT: Do not copy bats or tests.
+# ================= Stage 3 — final =================
 FROM builder AS final
-# (Optional) clean caches, strip docs
 CMD ["/bin/bash"]

--- a/terraform/docker/tests/00_core.bats
+++ b/terraform/docker/tests/00_core.bats
@@ -25,3 +25,78 @@ load 'test_helper/common.bash'
 @test "Node is installed" {
   check_binary node
 }
+
+
+@test "Stable devtools group exists with a numeric GID" {
+  run getent group devtools
+  assert_success
+  # Output example: devtools:x:2001:
+  [[ "${output}" =~ ^devtools:x:[0-9]+: ]] || {
+    echo "Unexpected devtools group line: ${output}" >&2
+    return 1
+  }
+}
+
+@test "/opt/bundle and /opt/rbenv/shims are group-owned by devtools and setgid" {
+  assert_devtools_setgid_dir "/opt/bundle"
+  assert_devtools_setgid_dir "/opt/rbenv/shims"
+}
+
+@test "/opt/pyenv and /opt/tenv are writable by devtools (runtime install support)" {
+  # Optional but expected per Dockerfile
+  for d in /opt/pyenv /opt/tenv; do
+    if [ -d "$d" ]; then
+      run bash -lc 'stat -c "%G %A %n" '"$d"
+      assert_success
+      [[ "${output}" == devtools* ]] || {
+        echo "Expected group 'devtools' for $d, got: ${output}" >&2
+        return 1
+      }
+      # quick writable check
+      run bash -lc '[ -w '"$d"' ]'
+      assert_success
+    fi
+  done
+}
+
+@test "New files/dirs under /opt/bundle inherit devtools group; dirs inherit setgid" {
+  work="/opt/bundle/bats_perm_test_$$"
+  run bash -lc 'mkdir -p '"$work"' && touch '"$work"'/f && stat -c "%G %A %n" '"$work"' '"$work"'/f'
+  assert_success
+
+  # Both dir and file must be group-owned by devtools
+  echo "$output" | awk '{print $1}' | while read g; do
+    [ "$g" = "devtools" ] || { echo "Non-devtools group seen: $g" >&2; exit 1; }
+  done
+
+  # Directory must have setgid bit (files do not)
+  run bash -lc 'test -d '"$work"' && find '"$work"' -maxdepth 0 -perm -2000 -print -quit'
+  assert_success
+  [ -n "${output}" ] || { echo "Expected setgid on $work" >&2; return 1; }
+
+  run bash -lc 'rm -rf '"$work"
+  assert_success
+}
+
+
+@test "PATH/rbenv initialization works in a login shell" {
+  # -l forces login shell -> /etc/profile.d/* should apply
+  run bash -lc 'command -v ruby && command -v rbenv && command -v bundler && echo "$PATH"'
+  assert_success
+  assert_output --partial "/opt/rbenv/shims"
+  assert_output --partial "/opt/rbenv/bin"
+  assert_output --partial "/opt/bundle/bin"
+  assert_output --partial "/opt/node/bin"
+}
+
+@test "PATH/rbenv initialization works in an interactive non-login shell" {
+  # -i (interactive) triggers /etc/bashrc -> /etc/bashrc.d/*
+  run bash -ic 'command -v ruby && command -v rbenv && command -v bundler && echo "$PATH"'
+  assert_success
+  assert_output --partial "/opt/rbenv/shims"
+  assert_output --partial "/opt/rbenv/bin"
+  assert_output --partial "/opt/bundle/bin"
+  assert_output --partial "/opt/node/bin"
+}
+
+

--- a/terraform/docker/tests/10_python.bats
+++ b/terraform/docker/tests/10_python.bats
@@ -24,3 +24,7 @@ load 'test_helper/common.bash'
 @test "pyenv is installed" {
   check_binary pyenv
 }
+
+@test "pre-commit is installed" {
+  check_binary pre-commit
+}

--- a/terraform/docker/tests/35_azure.bats
+++ b/terraform/docker/tests/35_azure.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+load 'test_helper/common.bash'
+
+# bats file_tags=azure
+
+
+# @azure
+@test "Azure CLI (az) is available" {
+  if command -v az >/dev/null; then
+    run az --version
+    assert_success
+  else
+    # Installed via `uv sync --directory /tmp`; run it from that project env
+    run uv run --directory /tmp az --version
+    assert_success
+  fi
+}
+

--- a/terraform/docker/tests/40_terraform.bats
+++ b/terraform/docker/tests/40_terraform.bats
@@ -3,11 +3,18 @@ load 'test_helper/common.bash'
 
 # bats file_tags=terraform
 
-@test "Terraform via tenv" {
+@test "Terraform via tenv works" {
   run tenv tf list
   assert_success
 }
 
-@test "TFLint" { check_binary tflint; }
+@test "TFLint Installed" { check_binary tflint; }
 
-@test "terraform-docs" { check_binary terraform-docs; }
+@test "terraform-docs Installed" { check_binary terraform-docs; }
+
+@test "terraform-config-inspect Installed" {
+  run terraform-config-inspect --json
+  assert_success
+}
+
+@test "tfsec Installed" { check_binary tfsec; }

--- a/terraform/docker/tests/50_ruby_ecosystem.bats
+++ b/terraform/docker/tests/50_ruby_ecosystem.bats
@@ -30,3 +30,9 @@ load 'test_helper/common.bash'
   run cinc-auditor version
   assert_success
 }
+
+
+@test "Kitchen and Cinc Auditor shims are resolvable from PATH (no manual chown needed)" {
+  run bash -lc 'command -v kitchen && command -v cinc-auditor'
+  assert_success
+}

--- a/terraform/docker/tests/60_k8s.bats
+++ b/terraform/docker/tests/60_k8s.bats
@@ -8,7 +8,7 @@ load 'test_helper/common.bash'
   if ! command -v kubectl >/dev/null; then
     skip "kubectl not provided in this image"
   fi
-  run kubectl version --client --short
+  run kubectl version --client
   assert_success
 }
 
@@ -17,6 +17,6 @@ load 'test_helper/common.bash'
   if ! command -v helm >/dev/null; then
     skip "Helm not provided in this image"
   fi
-  run helm version --short
+  run helm version
   assert_success
 }

--- a/terraform/docker/tests/test_helper/common.bash
+++ b/terraform/docker/tests/test_helper/common.bash
@@ -1,15 +1,49 @@
 #!/usr/bin/env bash
 # Common helper functions / variables
 
-load 'test_helper/bats-support/load'
-load 'test_helper/bats-assert/load'
+ load 'test_helper/bats-support/load'
+ load 'test_helper/bats-assert/load'
 
-# Ensure the user-local bin directory is searchable even for non‑login shells
-export PATH="$PATH:$HOME/.local/bin:/opt/bundle/bin"
+ # Ensure the user-local bin directory is searchable even for non-login shells
+ export PATH="$PATH:$HOME/.local/bin:/opt/bundle/bin"
 
-# Short helper for “binary exists and prints a version”
-check_binary() {
-  local exe="$1"
-  run "$exe" --version
+ # Short helper for “binary exists and prints a version”
+ check_binary() {
+   local exe="$1"
+   run "$exe" --version
+   assert_success
+ }
+
+# Return "gid:<gid>" for a group, or empty if not found
+get_gid_of_group() {
+  local grp="$1"
+  getent group "$grp" | awk -F: '{print "gid:"$3}'
+}
+# Assert a path is group-owned by `devtools` AND has setgid bit
+assert_devtools_setgid_dir() {
+  local p="$1"
+  run bash -lc 'stat -c "%G %a %A %n" '"$p"
   assert_success
+  # Expect group=devtools
+  [[ "${output}" == devtools* ]] || {
+    echo "Expected group 'devtools' for $p, got: ${output}" >&2
+    return 1
+  }
+  # Expect setgid bit (2xxx) and at least g+rwX (775 typical)
+  # Check via find -perm -2000
+  run bash -lc 'test -d '"$p"' && find '"$p"' -maxdepth 0 -perm -2000 -print -quit'
+  assert_success
+  [[ -n "${output}" ]] || {
+    echo "Expected setgid bit on directory $p" >&2
+    return 1
+  }
+}
+
+# Echo 1 if PATH contains a segment, else 0
+path_contains() {
+  local seg="$1"
+  case ":$PATH:" in
+    *":$seg:"*) echo 1;;
+    *) echo 0;;
+  esac
 }


### PR DESCRIPTION
# Problem

Python libs (Azure CLI, pre-commit etc) installed via https://github.com/effektiv-ai/terrarium-kubectl/blob/5177c8e672d1db80c1e202e7dadabd1f491e0d40/terraform/docker/python_requirements were not made available on the path

# Solution

The directory to which these tools are installed is now included on the path.