### PR TITLE
chore(release): 4.8.1 housekeeping — version alignment & changelog consolidation

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -11,13 +11,13 @@ on:
   push:
     branches: [master]
     paths:
-      - 'docker/**'
-      - '.github/workflows/scan.yaml'
+      - "docker/**"
+      - ".github/workflows/scan.yaml"
   pull_request:
     branches: [master]
     paths:
-      - 'docker/**'
-      - '.github/workflows/scan.yaml'
+      - "docker/**"
+      - ".github/workflows/scan.yaml"
   # Also run after the build workflow completes (image may now be in GHCR)
   workflow_run:
     workflows: ["Build, test & publish terrarium"]
@@ -31,8 +31,8 @@ on:
         description: "Dump GitHub contexts for debugging"
         type: boolean
         default: false
-  schedule:
-    - cron: "0 6 * * 1"  # Weekly Monday 06:00 UTC
+  # schedule:
+  #   - cron: "0 6 * * 1"  # Weekly Monday 06:00 UTC
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## [Unreleased]
 
-## [4.8.2] 2026-04-21 — PGP vendor-key unification, tenv expired-key fix, Jenkins-agent tool alignment, Dependabot integration
+## [4.8.1] 2026-04-22 - Housekeeping PR  - PR #72
+
+4.8.1-pre has been tested and appears to be in good shape for a release.
+
+### Changed
+
+- Disabled daily trivy scans to reduce CICD noise
+- Cleaned up changelog to more accurately reflect versioning and releases
+
+## [4.8.1-pre] 2026-04-21 — PGP vendor-key unification, tenv expired-key fix, Jenkins-agent tool alignment, Dependabot integration  - PR #71
 
 ### Added
 
@@ -57,7 +66,7 @@
 - TOOLS_AND_LICENSES: pinned base-image rows to `ubi9/ubi:9.5` and `rockylinux:9.3` to match Dockerfile ARGs.
 - Dockerfile: clarifying comment on the `test` stage explaining it is the deliberate publish target (bats suite intentionally ships in the image for consumer re-runs).
 
-## [4.8.1] - 2026-04-03 — Dockerfile hardening, image slimdown, CI improvements, test reorganisation
+## [4.8.1-pre] - 2026-04-03 — Dockerfile hardening, image slimdown, CI improvements, test reorganisation - PR #61
 
 ### Image slimdown (~350 MB reduction)
 


### PR DESCRIPTION
## Summary

Housekeeping PR to cut the **4.8.1** release. The previously merged and subsequently tested work (tenv PGP fix, unified vendor-key import, Jenkins-agent tool alignment, and the absorbed Dependabot bumps) is now validated end-to-end and ready to ship as a single **4.8.1** release rather than being stranded across pre-release labels. This PR collapses the versioning and fixes the changelog so downstream consumers have a clean, accurate release history.

## What's rolled into 4.8.1

The 4.8.1 release line consolidates work that was merged and validated across several PRs:

- **[#71](https://github.com/nichtraunzer/terrarium/pull/71)** — PGP vendor-key unification, tenv 4.9.3 → 4.11.1 (fixes expired HashiCorp key that was breaking `docker build`), dev-tooling extras (`ripgrep`, `chsh`, `ca-certificates`, `libyaml-devel`), Jenkins-agent tool-version alignment (terraform-2408 baseline).
- **[#61](https://github.com/nichtraunzer/terrarium/pull/61)** — Dockerfile hardening, ~350 MB image slimdown, CI improvements, test reorganisation.
- **Dependabot bumps absorbed**: `syslog` ([#58](https://github.com/nichtraunzer/terrarium/pull/58)), `step-security/harden-runner` ([#64](https://github.com/nichtraunzer/terrarium/pull/64)), `int128/docker-manifest-create-action` ([#65](https://github.com/nichtraunzer/terrarium/pull/65)), `github/codeql-action` ([#66](https://github.com/nichtraunzer/terrarium/pull/66)), `mixlib-install` ([#67](https://github.com/nichtraunzer/terrarium/pull/67)), `irb` ([#68](https://github.com/nichtraunzer/terrarium/pull/68)), `aws-sdk` ([#69](https://github.com/nichtraunzer/terrarium/pull/69)), `test-kitchen` ([#70](https://github.com/nichtraunzer/terrarium/pull/70)).

Each of the above has been tested on the built image via the `make docker-test` bats suite and validated in downstream dev-container usage.

## What this PR changes

- **Changelog renumbering** — the previous `[4.8.2] 2026-04-21` entry is relabelled `[4.8.1-pre]`, and the earlier `[4.8.1] 2026-04-03` entry is also relabelled `[4.8.1-pre]`. A new `[4.8.1] 2026-04-22` section summarises this housekeeping pass. Net effect: the release history now reads as a single coherent 4.8.1 line, with prior pre-release labels preserved for traceability.
- **Weekly Trivy scan cron disabled** — commented out the `0 6 * * 1` weekly scheduled run in `.github/workflows/scan.yaml` to reduce CI noise. Scans still run on every push/PR touching `docker/**` or the workflow itself, and on `workflow_run` after the build workflow completes, so coverage of actual changes is unchanged.
- **YAML quote-style normalisation** in `scan.yaml` (single → double quotes) for consistency.

## Test plan

- [x] `make docker-build` succeeds against the 4.8.1 content.
- [x] `make docker-test` bats suite green (including the new `ripgrep`, `chsh`, and CA-bundle smoke tests added in #71).
- [x] `make e2e` (3-stage runner: upstream → internal → devcontainer) green.
- [x] Manual devcontainer smoke test — image opens cleanly; `terrarium` user present in `/etc/passwd`; bats suite runnable at `/home/terrarium/tests` inside the running container.
- [x] `scan.yaml` workflow still triggers on `docker/**` pushes and `workflow_run` completion (cron removal only affects the weekly sweep).
